### PR TITLE
Removed invisible character 0xA0 from document base

### DIFF
--- a/advanced/index.md
+++ b/advanced/index.md
@@ -499,7 +499,7 @@ The full set of jigsaw pieces contains 192 such masks, in a 16 by 12 array, incl
 This specific jigsaw piece is a **100x100 pixel mask**, and designed to be used at a **+365+96 offset** on an **800x600 pixel image**.
 These figures are only important if you have a large set of different pieces that will fit together.
 If you don't plan to do this then of course you can use any offset you like.
- 
+
 [![\[photo\]](holocaust_tn.gif)](holocaust_md.jpg)
 [![\[IM Output\]](jigsaw_tmpl.png)](jigsaw_tmpl.png)
 

--- a/anim_basics/index.md
+++ b/anim_basics/index.md
@@ -65,7 +65,7 @@ As such I recommend that you always set "`-loop`" when creating a GIF animation,
 
 For more information see [The End of the Loop](#loop) below.
 
-`-delay {time}  `
+`-delay {time}`
 
 Set the time delay (in 1/100th of a second) to pause after drawing the images that are read in or created after this setting has been defined.
 
@@ -285,7 +285,7 @@ But that relies on knowing the history of the animation sequence which makes it 
 > See [Animation Bugs](../bugs/animation_bgnd/) for examples and details.
   
 These functions however did work fine when no pixel clearing was applied or intended.
-This has now been fixed for "`-coalesce`" and the "`-layers OptimizeFrame`' method was created to replace the use of "`-deconstruct`" as a GIF animation frame optimizing function.
+This has now been fixed for "`-coalesce`" and the "`-layers OptimizeFrame`' method was created to replace the use of "`-deconstruct`" as a GIF animation frame optimizing function.
 
 ------------------------------------------------------------------------
 

--- a/anim_mods/index.md
+++ b/anim_mods/index.md
@@ -1611,8 +1611,7 @@ convert bag_wing.gif -delete 2--1 -set delay 33 \
 [![\[IM Output\]](bag_bear_opt.gif)](bag_bear_opt.gif)
   
 [![\[IM Output\]](bag_wing_opt.gif)](bag_wing_opt.gif)
-  
- 
+
 As a final summary: The two original (badly split) images totalled [![\[IM Text\]](bag_orig_size.txt.gif)](bag_orig_size.txt) bytes, which is about the same as the appended version.
 After correctly splitting the animation, which allows good optimization of the sub-animations, we get a total of [![\[IM Text\]](bag_opt_size.txt.gif)](bag_opt_size.txt) bytes over three image.
 Quite a good saving.

--- a/anim_opt/index.md
+++ b/anim_opt/index.md
@@ -628,7 +628,7 @@ But that is not always possible, so if you are optimizing a modified GIF animati
 However if you have a animation with to many colors, the first thing you need to remember is...
 
 **Do not save directly to GIF format,  
- use the MIFF file format,   OR   separate PNG images.**
+ use the MIFF file format, OR separate PNG images.**
 
 As soon as you save to GIF, you have lost control of your GIF color optimization efforts, and you probably have a very bad looking GIF animation that will not optimize very well using various [Frame Optimization](#frame_opt) techniques.
 

--- a/anim_opt/index.md
+++ b/anim_opt/index.md
@@ -1016,7 +1016,7 @@ Of course Ordered Dither Compression Optimization only works for images that hav
 As such it only works for animations that have yet to be optimized for the GIF image format.
 
 Also currently IM Ordered dither only works for a uniform color palette.
-IM has yet to have a 'best color' or 'user supplied' palette implementation of ordered dither, though I have seen programs that use such an algorithm for very limited (and fixed) color pallets.
+IM has yet to have a 'best color' or 'user supplied' palette implementation of ordered dither, though I have seen programs that use such an algorithm for very limited (and fixed) color palettes.
 *Do you know of such an algorithm?*
 
 For a practical example of using ordered dither for improved LZW compression optimization, see [Ordered Dithered Video](../video/#gif_ordered_dither).

--- a/backgrounds/index.md
+++ b/backgrounds/index.md
@@ -10,7 +10,7 @@ Be sure to read the notes at the end, before attempting to create your own examp
 And please mail any interesting variations you may come across.
 
 Input Images :- Generator, Transform and Post-processing
- 
+
 *Images results shown here were generated with a "`-noop`" null transform operator*
 
 Plasma Fractal *(non-tiling canvas image)*

--- a/basics/index.md
+++ b/basics/index.md
@@ -2053,7 +2053,7 @@ Other settings include '`GrayScale`' and '`GrayScaleMatte`' which will ensure th
 
 During reading of image file formats, a "`-type`" setting of '`TrueColorMatte`' will force a [JPEG](../formats/#jpeg) image being read, to have a 'Matte' or 'Alpha' channel added to its in memory storage, even though the [JPEG](../formats/#jpeg) format itself can not handle transparency.
 
-When writing to a [PNG](../formats/#png_formats) file format setting a "`-type`" of '`Pallette`' will force it to use a color indexed "`PNG8`' internal image format. 
+When writing to a [PNG](../formats/#png_formats) file format setting a "`-type`" of '`Palette`' will force it to use a color indexed "`PNG8`' internal image format. 
 Similarly using "`BiLevel`" will force IM to dither color images to black and white for most image file formats.
 
 Unfortunately the exact meaning and capabilities of "`-type`" depend on the specific image format you are reading or writing. See the various [Image File Formats](../formats/) example areas. For specific PNG examples see [PNG output formats](../formats/#png_formats).

--- a/blur/index.md
+++ b/blur/index.md
@@ -54,7 +54,7 @@ A very small *sigma* (less than '`1`' ) limits their contribution to a small amo
 The largest *sigma* of '`65355`' will produce a simple averaging of all the pixels in the square neighbourhood.
 
 Also notice that for smallish *radius* but a large *sigma* you see artifacts appear in the blurred result.
-This is especially visible in the output for "`-blur 5x8`".
+This is especially visible in the output for "`-blur 5x8`".
 This is caused by the small square neighbourhood 'cutting off' the area blurred, producing sudden stops in the smooth Gaussian curve of the blur, and thus producing [Ringing Artefacts](../filter/#ringing) along sharp edges.
 So...
 

--- a/bugs/blur_trans/index.md
+++ b/bugs/blur_trans/index.md
@@ -140,14 +140,14 @@ composite -compose Atop -size 70x70 xc:yellow blur_black.png \
 You can do this in a single command, with the help of some IM v6 constructs.
 The one real difference here is we limited the blur to just the the alpha channel of the image.
 Yes that image will look horrible but it will not be seen in the output as we immediately replace the colors in the image, use some color canvas generation methods.
-  
-        convert -size 70x70 xc:none -draw 'circle 35,35 20,25' \
-                -channel A -blur 0x8 \
-                \( +clone  -fill green  -draw 'color 0,0 reset' \) \
-                -compose ATop -composite    blur_green.png
-     
 
-  
+~~~
+convert -size 70x70 xc:none -draw 'circle 35,35 20,25' \
+        -channel A -blur 0x8 \
+        \( +clone  -fill green  -draw 'color 0,0 reset' \) \
+        -compose ATop -composite    blur_green.png
+~~~
+
 [![\[IM Output\]](blur_green.png)](blur_green.png)
 
 Using "[`-compose ATop`](../../compose/#atop)" does not just limit you to a simple color.

--- a/color_mods/index.md
+++ b/color_mods/index.md
@@ -585,13 +585,10 @@ A threshold level for the contrast function to center on (typically centered at 
 > {\left ( \frac{1}{1 + \exp{\left( \beta * (\alpha - u ) \right )}} - \frac{1}{1 + \exp{\left ( \beta          \right ) }}\right ) }
 > {\left ( \frac{1}{1 + \exp{\left( \beta * (\alpha - 1 ) \right )}} - \frac{1}{1 + \exp{\left ( \beta * \alpha \right ) }}\right ) }
 > $$
->   
-><!-- ( 1/(1+exp(β*(α-u))) - 1/(1+exp(β))) / ( 1/(1+exp(β*(α-1))) - 1/(1+exp(β*α)) ) -->
 >
->  
->Where $\alpha$ is the threshold level, and $\beta$ the contrast factor to be applied.
+> Where $\alpha$ is the threshold level, and $\beta$ the contrast factor to be applied.
 >
->Here is a alternate version of the formula using intermediate variables.
+> Here is a alternate version of the formula using intermediate variables.
 >
 > $$
 > \begin{array}{l}
@@ -2823,10 +2820,10 @@ This will not just map the specified colors, but also re-map the colors between 
         -cycle     shift colormap (for animations of fractals???)
 
     Chromaticity Color Points???
-       –white-point x,y
-       –red-primary x,y
-       –green-primary x,y
-       –blue-primary x,y
+       -white-point x,y
+       -red-primary x,y
+       -green-primary x,y
+       -blue-primary x,y
 
 
     Thresholds  (after negation)

--- a/color_mods/index.md
+++ b/color_mods/index.md
@@ -204,8 +204,8 @@ The lower gradient is thus the same as the upper gradient.
 
 The simplest and most basic global level adjustment you can make is to negate the image, using the "`-negate`" image operator.
 
-Essentially this makes   white, black,   and   black, white,  , adjusting all the colors to match.
-That is, it will make the color red, its complementary color of cyan,   and blue, yellow, etc.
+Essentially this makes white, black, and black, white, adjusting all the colors to match.
+That is, it will make the color red, its complementary color of cyan, and blue, yellow, etc.
 
 You can see this with the mapping graph shown below, as I use the "`-negate`" operator on both the 'test' image and the standard IM 'rose' built-in image.
 Note how the lower gradient in the mapping graph image is now reversed, so that black and white are swapped, and the same reversal appearing in the negated 'test' image.
@@ -317,7 +317,7 @@ convert  rose:  -level -25%  rose_decontrast.gif
 This method of de-contrasting an image however is very inaccurate and not recommended, unless you have a IM older than version 6.4.2 where you don't have access to the new [Reversed Level Operator](#level_plus).
 ![\[IM Graph\]](gp_level_neg.gif)
 
-You can use the "`-level`" operator to negate an image (as previously shown above, just by swapping the 'black' and 'white' point values given, using "`-level 100%,0`".
+You can use the "`-level`" operator to negate an image (as previously shown above, just by swapping the 'black' and 'white' point values given, using "`-level 100%,0`".
 
 ~~~
 convert  rose:  -level 100%,0  rose_level_neg.gif
@@ -327,7 +327,7 @@ convert  rose:  -level 100%,0  rose_level_neg.gif
   
 ![\[IM Graph\]](gp_level_thres.gif) Or by setting them to the same value, you can effectively call all the color values in the image to be thresholded.
 Using "`-level`" to threshold an image is exactly the same as if you used a [Threshold Operator](../quantize/#threshold) with that value.
-The mapping graph shown right, shows the results of a "`-level 50%,50%`" operation, and its effect on a grayscale gradient.
+The mapping graph shown right, shows the results of a "`-level 50%,50%`" operation, and its effect on a grayscale gradient.
 
 ~~~
 convert  rose:  -level 50%,50%  rose_level_thres.gif
@@ -373,7 +373,7 @@ convert  rose:      -level 25%\!  rose_level_plus.gif
 [![\[IM Output\]](test_level_plus.png)](test_level_plus.png)  
 [![\[IM Output\]](rose_level_plus.gif)](rose_level_plus.gif)
 
-If you compare the above "`+level 25%`" operation with the use of a a negative de-contrasting, "`-level -25%`" operator we showed previously, you will see that are not the same.
+If you compare the above "`+level 25%`" operation with the use of a a negative de-contrasting, "`-level -25%`" operator we showed previously, you will see that are not the same.
 The 'plus' version produces a much stronger de-contrasted image (it is greyer), but does so by mapping to the exact values you give the operator, and not the 'imaginary' values the 'minus' form used.
 This exact value usage is important, and one of the reasons why the 'plus' form of the operator was added.
 

--- a/compare/index.md
+++ b/compare/index.md
@@ -1,13 +1,15 @@
 # Image Comparing
 
-The ability to compare two or more images, or finding duplicate images in a large collection, is a very tricky matter.
-In these examples we look at comparing images to determine how they similar they are, and where they differ.
+Comparing two or more images, and finding duplicate images in a large collection, are both very tricky matters.
+In these examples, we look at comparing images to determine how similar they are, and where they differ.
 
-This may involve classifying or grouping images into various types for better handling.
-Discovering some [metric](http://en.wikipedia.org/wiki/Metric_%28mathematics%29) to simplify and group similar images.
-And [clustering](http://en.wikipedia.org/wiki/Data_clustering) similar images together based on such metrics.
+This may involve:
 
-However such comparisons, and or studies while difficult can be rewarding, with the ability to find image duplicates, copies, and even removal of 'spam' or other text or notices from images.
+- classifying, or grouping images into various types for better handling
+- discovering some [metric](http://en.wikipedia.org/wiki/Metric_%28mathematics%29) to simplify and group similar images
+- and [clustering](http://en.wikipedia.org/wiki/Data_clustering) similar images together based on such metrics.
+
+However, such comparisons, and/or studies while difficult, can be rewarding, with the ability to find image duplicates, copies, and even remove 'spam' or other text or notices from images.
 
 ------------------------------------------------------------------------
 
@@ -17,7 +19,7 @@ However such comparisons, and or studies while difficult can be rewarding, with 
 
 The "`compare`" program is provided to give you an easy way to compare two similar images, to determine just how 'different' the images are.
 
-For example here I have two frames of a animated 'bag', which I then gave to "`compare`' to highlight the areas where it changed.
+For example, here I have two frames of an animated 'bag', which I then gave to "`compare`' to highlight the areas where it changed.
 
 ~~~
 compare bag_frame1.gif bag_frame2.gif  compare.gif
@@ -28,18 +30,18 @@ compare bag_frame1.gif bag_frame2.gif  compare.gif
 ![==&gt;](../img_www/right.gif)
 [![\[IM Output\]](compare.gif)](compare.gif)
 
-As you can see you get a white and red image, which has a 'shadow' of the second image in it.
-It clearly shows that three areas that changed between the two images.
+As you can see, you get a white and red image, which has a 'shadow' of the second image in it.
+It clearly shows the three areas that changed between the two images.
 
-Rather than saving the 'compare' image, you can of course view it directly, which I find more convenient, by output to the special "`x:`" output format, or using the "`display`" program.
-For example..
+Rather than saving the 'compare' image, you can, of course, view it directly, which I find more convenient, by output to the special "`x:`" output format, or using the "`display`" program.
+For example...
 
 ~~~
 compare bag_frame1.gif bag_frame2.gif  x:
 compare bag_frame1.gif bag_frame2.gif  miff:- | display
 ~~~
 
-As of IM v6.4 you can change the color of the differences from red to some other more interesting color...
+As of IM v6.4, you can change the color of the differences from red to some other more interesting color...
 
 ~~~
 compare bag_frame1.gif bag_frame2.gif \
@@ -48,7 +50,7 @@ compare bag_frame1.gif bag_frame2.gif \
 
 [![\[IM Output\]](compare_color.gif)](compare_color.gif)
 
-As of IM v6.4.2-8 you can specify the other color as well.
+As of IM v6.4.2-8, you can specify the other color as well.
 
 ~~~
 compare bag_frame1.gif bag_frame2.gif \
@@ -77,8 +79,8 @@ compare bag_frame1.gif bag_frame2.gif \
 
 [![\[IM Output\]](compare_mask.gif)](compare_mask.gif)
 
-Note however that this mask is of ANY difference, even the smallest difference.
-For example you can see all the minor differences that saving an image to the [Lossy JPEG Format](../formats/#jpg) produces...
+Note however, that this mask is of ANY difference, even the smallest difference.
+For example, you can see all the minor differences that saving an image to the [Lossy JPEG Format](../formats/#jpg) produces...
 
 ~~~
 convert bag_frame1.gif  bag_frame1.jpg
@@ -87,7 +89,7 @@ compare bag_frame1.gif bag_frame1.jpg   compare_lossy_jpeg.gif
 
 [![\[IM Output\]](bag_frame1.gif)](bag_frame1.gif) [![\[IM Output\]](bag_frame1.jpg)](bag_frame1.jpg) ![==&gt;](../img_www/right.gif) [![\[IM Output\]](compare_lossy_jpeg.gif)](compare_lossy_jpeg.gif)
 
-As you can see even though you can't really see any difference between GIF and the JPEG versions of the image, "`compare`" reports a lot of differences.
+As you can see, even though you can't really perceive any difference between the GIF and the JPEG versions of the image, "`compare`" reports a lot of differences.
 
 By using a small [Fuzz Factor](../color_basics/#fuzz) you can ask IM to ignore these minor differences between the two images.
 
@@ -102,11 +104,11 @@ compare -metric AE -fuzz 5% \
 
 Which shows that most of the actual differences are only minor.
 
-The special "`-metric`" setting of '`AE`' (short for "Absolute Error" count), will report (to standard error), a count of the actual number of pixels that were masked, at the current fuzz factor.
+The special "`-metric`" setting of '`AE`' (short for "Absolute Error" count), will report (to standard error), a count of the number of pixels that were masked, at the current fuzz factor.
 
 ### Difference Images {#difference}
 
-To get a better idea of exactly how different the images are, you are probably better of getting a more exact '`difference`' composition image....
+To get a better idea of exactly how different the images are, you are probably better off getting a more exact '`difference`' composition image....
 
 ~~~
 composite bag_frame1.gif bag_frame1.jpg \
@@ -115,7 +117,7 @@ composite bag_frame1.gif bag_frame1.jpg \
 
 [![\[IM Output\]](difference_jpeg.gif)](difference_jpeg.gif)
 
-As you can see while "`compare`" showed that JPEG created a lot of differences between the images, a '`difference`' composition was quite dark, indicating that all the differences were relatively minor.
+As you can see, while "`compare`" showed that JPEG created a lot of differences between the images, a '`difference`' composition was quite dark, indicating that all the differences were relatively minor.
 
 If the resulting image looks too black to see the differences, you may like to [Normalize](../color_mods/#normalize) the image (using the more mathematically correct "`-auto-level`", so as to enhance the results.
 
@@ -125,9 +127,9 @@ convert difference_jpeg.gif  -auto-level  difference_norm.gif
 
 [![\[IM Output\]](difference_norm.gif)](difference_norm.gif)
 
-This still shows that most of the differences are still very minor, with the largest difference occurring along the sharp edges of the image, which the JPEG image file format does not handle very well.
+This still shows that most of the differences are very minor, with the largest difference occurring along the sharp edges of the image, which the JPEG image file format does not handle very well.
 
-On the other hand getting a difference image between the two original frames of the animation shows a very marked differences between the two images, even without any enhancement.
+On the other hand, getting a difference image between the two original frames of the animation shows very marked differences between the two images, even without any enhancement.
 
 ~~~
 composite bag_frame1.gif bag_frame2.gif \
@@ -138,8 +140,8 @@ composite bag_frame1.gif bag_frame2.gif \
 
 Note that as the '`difference`' compose method is associative, the order of the two images in the above examples does not matter, although unlike "`compare`", you can compare different sized images, with the destination image determining the final size of the difference image.
 
-The different method is even more useful when used with the "`convert`" program, as you can process the resulting image further before saving or displaying the results.
-For example you can threshold and merge each of the color channels to to generate a mask of any pixel that changed color between the two images.
+The "difference" method is even more useful when used with the "`convert`" program, as you can process the resulting image further before saving or displaying the results.
+For example, you can threshold and merge each of the color channels to generate a mask of any pixel that changed color between the two images.
 
 ~~~
 convert bag_frame1.gif bag_frame2.gif -compose difference -composite \
@@ -151,12 +153,12 @@ convert bag_frame1.gif bag_frame2.gif -compose difference -composite \
 
 This is basically what the "`compare`" program does, but with more controls as to the color and output style.
 
-However as you can see it tends to find even the smallest minor change between two images.
+However, as you can see, it tends to find even the smallest differences between two images.
 If the images are from a lossy image file format, such as JPEG, or a GIF image that required color reduction and dithering (color quantization), then that would probably match everything in the image.
-As such it it typically not very useful.
+As such, it is typically not very useful.
 
-For better results you can try to figure out just how different the pixel colors are.
-For example we can gray-scale the result, so as to get a better comparison image, than a colorful one.
+For better results, you can try to figure out just how different the pixel colors are.
+For example, we can gray-scale the result, so as to get a better comparison image, rather than a colorful one.
 
 ~~~
 convert bag_frame1.gif bag_frame2.gif -compose difference -composite \
@@ -165,15 +167,15 @@ convert bag_frame1.gif bag_frame2.gif -compose difference -composite \
 
 [![\[IM Output\]](difference_gray.gif)](difference_gray.gif)
 
-Now unlike "`compare`", the difference image shows a mixture of both images combined in the final result.
-For example look at the weird 'talisman' seems to appear in the forehead of the cat.
+Now, unlike "`compare`", the difference image shows a mixture of both images combined in the final result.
+For example, look at the weird 'talisman' that seems to appear in the forehead of the cat.
 This was originally the handle of the bag from the first image.
-This merger can make it confusing as to exactly what differences you are seeing, and you see a megere of both the additions and removals from the image.
+This merger can make it confusing as to exactly what differences you are seeing, since you see a merge of both the additions and removals from the image.
 
-Because of this confusion of details, the "`compare`" is usually the better way for us humans to view, while the 'difference' image is the better method for further processing the image.
+Because of this confusion of details, the "`compare`" is usually the better way for us humans to view, while the 'difference' image is the better method for further computer processing the image.
 
-However grayscaling a difference image will simply average (actually a weighted average) the RGB distances together.
-As a result a single bit color difference could be lost though [Quantum Rounding Effects](../basics/#quantum_effects).
+However, grayscaling a difference image will simply average (actually a weighted average) the RGB distances together.
+As a result, a single bit color difference could be lost though [Quantum Rounding Effects](../basics/#quantum_effects).
 
 If even the smallest difference between images is important, a better method is to add the separate color channels of the difference image, to ensure you capture ALL the differences, including the most minor difference.
 
@@ -185,10 +187,10 @@ convert bag_frame1.gif bag_frame2.gif -compose difference -composite \
 [![\[IM Output\]](difference_add.gif)](difference_add.gif)
 
 The difference values produced in the above is known as a 'manhattan distance' metric.
-That is the distance between the two colors of each image when you are restricted to orthogonal (or axial) movement.
-Be warned however that large differences may become clipped (or burned) as it can exceed the pixel data 'Quantium Range', or integer limits, unless using a HDRI version of IM.
+That is, the distance between the two colors of each image when you are restricted to orthogonal (or axial) movement.
+Be warned however, that large differences may become clipped (or burned) as it can exceed the pixel data 'Quantum Range', or integer limits, unless using a HDRI version of IM.
 
-To take this further you can get the color vector distance, by using some squares and square roots to implement a Pythagorean or Euclidean distance.
+To take this further, you can get the color vector distance, by using some squares and square roots to implement a Pythagorean or Euclidean distance.
 
 ~~~
 convert bag_frame1.gif bag_frame2.gif -compose difference -composite \
@@ -198,11 +200,11 @@ convert bag_frame1.gif bag_frame2.gif -compose difference -composite \
 
 [![\[IM Output\]](difference_vector.gif)](difference_vector.gif)
 
-This is in fact similar what a 'fuzz' factor actually measures as part of its thresholding (when no transparency is involved).
-However 'fuzz' also divides the squared values by 3, before adding, to ensure the results do not exceed the image color range limits.
-Doing this means you would only get a pure 'white' pixel in the result for difference between opposite primary and secondary colors, such between a blue and yellow pixel.
+This is, in fact, similar to what a 'fuzz' factor actually measures as part of its thresholding (when no transparency is involved).
+However 'fuzz' also divides the squared values by 3 before adding, to ensure the results do not exceed the image color range limits.
+Doing this means you would only get a pure 'white' pixel in the result for difference between opposite primary and secondary colors, such as between a blue and yellow pixel.
 
-So lets do that scaling too...
+So let's do that scaling too...
 
 ~~~
 convert bag_frame1.gif bag_frame2.gif -compose difference -composite \
@@ -213,13 +215,13 @@ convert bag_frame1.gif bag_frame2.gif -compose difference -composite \
 
 [![\[IM Output\]](difference_vector_scaled.gif)](difference_vector_scaled.gif)
 
-This is actually very similar to what you would get for a "`-colorspace Gray`' difference image (as above), but it is much more accuriate representation of color difference.
+This is actually very similar to what you would get for a "`-colorspace Gray`' difference image (as above), but it is a much more accurate representation of color difference.
 
-You could leave of the second '`Pow 0.5`' modification in which case you will get a Squared difference Image.
+You could leave off the second '`Pow 0.5`' modification, in which case you will get a Squared difference Image.
 
 There are other color distance metrics, which you can read about on the [Color Difference, Wikipedia](http://en.wikipedia.org/wiki/Color_difference) page.
 Most of these involve generating vector differences (see last) but using a different colorspace, such as LAB or LUV.
-This would however be more important in comparing real world color differences (EG: human vision difference measures).
+This would however be more important in comparing real world color differences (e.g.: human vision difference measures).
 
 Also see [Background Removal](../masking/#bg_remove), where difference images like the above are used to perform background removal.
 You may also like to look at this external page on [Change Detection](http://ecocam.evsc.virginia.edu/change_detection_description/change_detection_description.htm) as a practical example of its use.
@@ -234,7 +236,7 @@ convert -delay 50 bag_frame1.gif bag_frame2.gif -loop 0 flicker_cmp.gif
 
 [![\[IM Output\]](flicker_cmp.gif)](flicker_cmp.gif)
 
-To make this easier I wrote a script to display an animation of two given images called "`flicker_cmp`" which flips between the two images, just like the above example.
+To make this easier, I wrote a script to display an animation of two given images called "`flicker_cmp`" which flips between the two images, just like the above example.
 It also adds a label at the bottom of the displayed image so as to detail which image you are seeing at any particular moment.
 
 ### Comparing Animations {#animation}
@@ -242,7 +244,7 @@ It also adds a label at the bottom of the displayed image so as to detail which 
 You can also compare the differences in two coalesced animations using a special 'film strip' technique.
 See a similar 'append' technique in [Side by Side Appending](../anim_mods/#append).
 
-Basically we append all the animation frames together to form one large, and long image.
+Basically, we append all the animation frames together to form one large, and long image.
 The two images are then compared and a new animation is created by splitting up the animation into separate frames again.
 For example...
 
@@ -253,13 +255,13 @@ convert \( anim1.gif -coalesce -append \) \
     convert - -crop 160x120 +repage anim_compare.gif
 ~~~
 
-The result is a animation of the 'compare' images, producing a 'dimmed' version of the second animation, overlaid with a highlight showing the parts which are different.
+The result is an animation of the 'compare' images, producing a 'dimmed' version of the second animation, overlaid with a highlight showing the parts which are different.
 
-Note that for this to work the "`-crop`" size much match the original size of the animation.
-Also the animation will lose any variable time delays that it may have had, using a constant time delay based on the first frame of the original animation.
+Note that for this to work, the "`-crop`" size much match the original size of the animation.
+Also, the animation will lose any variable time delays that it may have had, because it uses a constant time delay based on the first frame of the original animation.
 
 Another image comparison technique useful for animations is used to locate all the areas in which an animation changes, so as to divide the animation's unconnected parts.
-This way you can separate a large animations into a number of smaller animations.
+This way you can separate large animations into a number of smaller animations.
 See [Splitting up an Animation](../anim_mods/#split).
 
 ------------------------------------------------------------------------
@@ -298,7 +300,7 @@ Just how different are two images?
 
     Compare  Program  Statistics...
 
-       You can get a actual average difference value using the -metric
+       You can get an actual average difference value using the -metric
 
          compare -metric MAE image1 image2 null: 2>&1
 
@@ -314,24 +316,24 @@ Just how different are two images?
             blue: 2008.67 (0.0306503)
             all: 1536.39 (0.0234439)
 
-       Their are a number of different metrics to chose from.
+       There are a number of different metrics to chose from.
        With the same set of test images (mostly the same)
 
        Number of pixels
           AE ...... Absolute Error count of the number of different pixels (0=equal)
 
                     This value can be thresholded using a -fuzz setting to
-                    only count pixels that have a larger then the threshold.
+                    only count pixels that have a value larger than the threshold.
 
-                    As of IM v6.4.3  the  -metric AE  count is -fuzz effected.
-                    so you can discount 'minor' differences from this count.
+                    As of IM v6.4.3  the  -metric AE  count is -fuzz affected.
+                    so you can remove 'minor' differences from this count.
 
                     convert -metric AE -fuzz 10% image1.png image2.png null:
 
                     Which pixels are different can be seen using the output
                     image (ignored in the above command).
 
-                    This is the ONLY metric which is 'fuzz' effected.
+                    This is the ONLY metric which is 'fuzz' affected.
 
        Maximum Error (of any one pixel)
           PAE ..... Peak Absolute Error   (within a channel, for 3D color space)
@@ -340,23 +342,23 @@ Just how different are two images?
                     that can exist between any two images, expressed as a decibel
                     value.
 
-                    The higher the PSNR the closer the closer the images are, with
+                    The higher the PSNR, the closer the images are, with
                     a maximum difference occurring at 1.  A PSNR of 20 means
                     differences are 1/100 of maximum.
 
        Average Error (over all pixels)
           MAE ..... Mean absolute error    (average channel error distance)
           MSE ..... Mean squared error     (averaged squared error distance)
-          RMSE .... (sq)root mean squared error -- IE:  sqrt(MSE)
+          RMSE .... (sq)root mean squared error -- i.e.:  sqrt(MSE)
 
 
        Specialized metrics
           MEPP .... Normalized Mean Error AND Normalized Maximum Error
-                    These should directly related to the '-fuzz' factor,
+                    These should be directly related to the '-fuzz' factor,
                     for images without transparency.
 
                     With transparency, makes this difficult the mask should
-                    effect the number of pixels compared, and thus the 'mean'
+                    affect the number of pixels compared, and thus the 'mean'
                     but this is currently not done.
 
           FUZZ      fuzz factor difference taking transparency into account
@@ -377,38 +379,38 @@ Just how different are two images?
        differences, where the test image was read in and saved with a very low
        -quality setting.
 
-       The second "black vs white", is a compare of a solid black image verses
+       The second "black vs white", is a compare of a solid black image versus
        a solid white image.  If the 'average color' of the image is ignored
        by the comparision then the resulting value will be very small.  This
        seems only to be the case with the PSNR metric, as all others produced
        a maximum difference value.
 
        The e+06 is scientific notation, on how many places to shift the
-       decimal point.  EG:   4.65489e+06  -->  4,654,890.0
+       decimal point.  e.g.:   4.65489e+06  -->  4,654,890.0
        Thus is equal to about 4 million, and is the square of 2157.52
 
        WARNING: numbers are dependant on the IM Quality (Q) levels set at compile
-       time. The higher the quality the larger the numbers. Only PSNR should be
-       unaffected by this.  For this reason IM also gives you a 'normalized'
-       result that is uneffected by the compile time quality setting, though may
-       still have minor 'quantum' or 'interger rounding' effects.
+       time. The higher the quality, the larger the numbers. Only PSNR should be
+       unaffected by this.  For this reason, IM also gives you a 'normalized'
+       result that is unaffected by the compile time quality setting, though may
+       still have minor 'quantum' or 'integer rounding' effects.
 
-       I have NOT figured out if there are any of the existing "-define" options
-       usable the "compare" function.
+       I have NOT figured out if any of the existing "-define" options are 
+       usable by the "compare" function.
 
 
-       NOTE for opaque colors AE -fuzz  and RMSE distances are equivalent.
+       NOTE for opaque colors, "AE", "-fuzz"  and "RMSE" distances are equivalent.
        HOWEVER,  when transparent colors are involved AE fuzz factor testing
        will treat two different fully-transparent colors as being the same
-       while RMSE will treate them as being different!
+       while RMSE will treat them as being different!
 
        For example...
-       To AE fully-transparent white and fully-transparent black are the same.
+       To the "AE" metric, fully-transparent white and fully-transparent black are the same.
 
          compare -metric AE xc:#0000 xc:#FFF0 null:
          0
 
-       But to RMSE they are VERY different
+       But to the "RMSE" metric, they are VERY different
 
          compare -metric RMSE xc:#0000 xc:#FFF0 null:
          56755 (0.866025)
@@ -447,10 +449,10 @@ For more info, see my very old raw text notes...
       a very accurate color comparison.
 
       The search basically does a compare of the small image at EVERY possible
-      location in the larger image.  As such it is is slow! very very slow..
+      location in the larger image.  As such it is slow - very, very slow.
 
-      The best idea is to compare a very very SMALL sub-image to find possible
-      locations, than use that to then do a difference compare at each possible
+      The best idea is to compare a very, very SMALL sub-image to find possible
+      locations, then use that to do a difference compare at each possible
       location for a more accurate match.
 
       Have a look at the script
@@ -476,28 +478,27 @@ For more info, see my very old raw text notes...
 
     Similarity Threshold
 
-      As many time people are only interested in the first match that matches.
-      As soon at this 'good' match is found, there is no need to continue
-      searching for another match.  The -similarity-metric defines what you
+      As, many times, people are only interested in the first match, as soon at this is found, there is no need to continue
+      searching.  The -similarity-metric defines what you
       would regard as a good match.
 
       A "-similarity-threshold 0.0" will abort on the very first 'perfect' match
       found, while "-similarity-threshold 1.0"  (the default) will never match and
-      will search every posible point.  A value between will set a color only
-      'fuzz' factor on what you would find an acceptable match.
+      will search every posible point.  A value in between will set a "color only"
+      'fuzz' factor on what you would consider an acceptable match.
 
       Note that if the sub-image search is aborted, the second 'map' image will
-      only contain a partial result, only showing the results up until the comapre
-      aborted its search).
+      contain a partial result, only showing the results up until the compare
+      aborted its search.
 
 
     Some Basic Sub-Image Search Examples....
 
       Grab a screen shot of a terminal window ("screen.png"),
-      and crop out a image of a single letter or word ("letter.png").
+      and crop out an image of a single letter or word ("letter.png").
 
       Just report first match.... for speed,
-      immeditally abort after finding that first match.
+      immediately abort after finding that first match.
       Don't bother outputing the incomplete image results.
 
          compare -subimage-search -metric AE -similarity-threshold 1.0 \
@@ -506,15 +507,15 @@ For more info, see my very old raw text notes...
       NOTE speed will be highly dependant on where in the image that first
       match is found.
 
-      Find all occurances of exactly that image,
-      as a image (white dots on matches, black elsewhere)
+      Find all occurences of exactly that image,
+      as an image (white dots on matches, black elsewhere)
 
          compare -subimage-search -metric AE \
                        screen.png letter.png miff:- 2>/dev/null |
            convert - -delete 0 show:
 
       Extract a list of the coordinates of all matching letters (white dots)
-      (as a enumerated pixel list, ignoring anything black)
+      (as an enumerated pixel list, ignoring anything black)
 
          compare -subimage-search -metric AE \
                        screen.png letter.png miff:-  2>/dev/null |
@@ -553,9 +554,9 @@ For more info, see my very old raw text notes...
 
     HitAndMiss Morphology
 
-      This is essentially a binary match, where you define what pixels much be
-      'background' and what must be forground.  However it also allows you to
-      define areas where you don't care if the result is a foregorund or
+      This is essentially a binary match, where you define what pixels must be
+      'background' and what must be 'foreground'.  However, it also allows you to
+      define areas where you don't care if the pixel is foreground or
       background.
 
       Basically a binary pattern search method.
@@ -563,24 +564,24 @@ For more info, see my very old raw text notes...
     Correlate (a Convolve variant)
 
       This is similar to Hit and Miss but using greyscale values.  Positive values
-      for forground and negative values for background, and zero for don't care.
+      for foreground and negative values for background, and zero for don't care.
       It is however limited to grayscale images.
 
       See Correlation and Shape Searching.
 
       Both of these are basically just as slow as the previous sub-image compare,
-      but less accurate with regards to colors.  However it's ability to specify
-      specify a shape (don't care areas) to the sub-image makes then useful as
-      a search method.
+      but less accurate with regards to colors.  However, the ability to 
+      specify a shape (don't care areas) to the sub-image makes them useful as
+      search methods.
 
       However you need to convert the sub-image into a 'kernel', or array of
-      floating point values, rather than as a actual image.
+      floating point values, rather than use an actual image.
 
 
     FFT Convolve (NCC)
 
       Fast Fourier Transforms is a slow operator, but usually many orders of
-      magnitude faster than the previous two methods use.  The reason is that
+      magnitude faster than the previous two methods.  The reason is that
       a convolution in the frequency domain is just a direct pixel by pixel
       multiplication.
 
@@ -592,13 +593,13 @@ For more info, see my very old raw text notes...
       a sub-image search, very very quickly, compared to the previous, especially
       with larger sub-images that can be the same size as the original image!
 
-      This I believe has been added as a NCC compare metric.
+      This I believe has been added as a "NCC" compare metric.
 
 
 
     Peak Finding and extracting (for near partial matches)...
 
-      Once you have compared the image you will typically have a 'probably map'
+      Once you have compared the image you will typically have a 'probability map'
       of some kind which defines how 'perfect' the match was.
 
       What you want to do now is to find the best match, or perhaps multiple
@@ -624,7 +625,7 @@ For more info, see my very old raw text notes...
                   txt:- | grep -v black
 
         The problem is you can get a cluster of points at a peak, rather than
-        a definitive pixel, especially for two peak pixel surrounded by very low
+        a definitive pixel, especially for two peak pixels surrounded by very low
         values.
 
       * Using a Peaks Hit and Miss Morphology Kernel
@@ -661,12 +662,12 @@ For more info, see my very old raw text notes...
 
       * Sub-pixel locating
 
-        If the peak is not a exact pixel, but could conceivably be a sub-pixel
+        If the peak is not an exact pixel location, but could conceivably be a sub-pixel
         location (between pixels) then some form of pattern match (gaussian curve
         fit) in the area of the peak may let you locate the peak to a sub-pixel
         coordinate.
 
-        This may be more important in image registration for parorama stitching,
+        This may be more important in image registration for panorama stitching,
         especially when you are not using a large number points to get a best-fit
         average of the perspective overlay.
 
@@ -688,20 +689,20 @@ For more info, see my very old raw text notes...
       distances.
 
 
-      While compare actually does real comparing of color vectors.  This will find
-      shapes better than correlate but is much much slower.
+      While "`compare`" actually does real comparing of color vectors.  This will find
+      shapes better than "`correlate`" but is much much slower.
 
-      As such to make proper use of correlate you should convert your images
-      (before hand for speed, or afterward against results) to try and highlight
-      the color differences in the image as a greyscale 'correaltion' image.
+      As such, to make proper use of "`correlate`" you should convert your images
+      (beforehand for speed, or afterward against results) to try and highlight
+      the color differences in the image as a greyscale 'correlation' image.
 
-      ASIDE: Use -channel to limit operations to one greyscale channel will
+      ASIDE: Using "-channel" to limit operations to one greyscale channel will
       improve speed.  In IMv7 greyscaling will reduce images to one channel so
       will gain speed improvements automatically.
 
-      For example instead of intensity, you may get a better foreground
-      / background differentiation, by extracting the  Hue of an image.
-      Though you may need to color rotate the hue's if there is a lot of red
+      For example, instead of intensity, you may get a better foreground
+      /background differentiation, by extracting the Hue of an image.
+      Though you may need to color rotate the hues if there is a lot of red
       in the sub-image being searched for.
 
       See the examples of HSL and HSB, channel separation, to see this problem.
@@ -717,7 +718,7 @@ For more info, see my very old raw text notes...
 
       You may like to also look at directional or compass type edge detection.
 
-      Basically Anything that will enhance the shape for your specific case is
+      Basically, anything that will enhance the shape for your specific case is
       a good idea.  Just apply it to BOTH images before correlating them.
 
 
@@ -752,12 +753,13 @@ For more info, see my very old raw text notes...
 
 #### Identical files
 
-Are the files binary identical that is they are exactly the same file and probably just exact copies of each other.
+Are the files binary identical?
+That is, they are exactly the same file and probably just exact copies of each other.
 No ImageMagick required.
 
 Don't discount this.
-You can compare lots of files very very quickly in this way.
-The best method I've found is by using MD5 check sums.
+You can compare lots of files very, very quickly in this way.
+The best method I've found is by using MD5 checksums.
 
 ~~~
 md5sum * | sort | awk {'print $2 " " $1'}  | uniq -Df 1
@@ -767,7 +769,7 @@ And that will list the md5's of images that are identical.
 
 Using this technique I created scripts that can generate and compare md5sum lists of files returning the files that are md5 identical.
 
-Note however that any change to a image file other than a direct copy, will be classed by this as being different, even if the image data itself is the same.
+Note however that any change to an image file other than a direct copy, will be classed by this as being different, even if the image data itself is the same.
 It only takes a date change or other minor meta-data difference in the file to make the image different.
 
 #### IM Image Signatures
@@ -779,31 +781,30 @@ identify -quiet -format "%#" images...
 ~~~
 
 The generates a hash string much like MD5 and SHA256 do.
-However unlike the latter, it uses the actual image data to generate the signiture, not the images metadata.
+However, unlike the latter, it uses only the actual image data to generate the signature, not the image's metadata.
 
-Thus, if you have two copies of the same picture but with different creation/modification timestamps, you should get same signature for both files, whereas MD5 and SHA256 will produce two signatures even though the image itself is the same.
+Thus, if you have two copies of the same picture but with different creation/modification timestamps, you should get same signature for both files, whereas MD5 and SHA256 will produce two different signatures even though the image itself is the same.
 
 WARNING: reading and writing a JPEG image will generate different image data and thus a different signature.
 This is simply due to the lossy compression JPEG image format uses.
 
 #### Direct Comparison
 
-You can directly compare two images (using the "`compare`" program) if they are the same size, to see how well they match.
-(See above)
+You can directly compare two images (using the "`compare`" program) if they are the same size, to see how well they match - see above.
 
-This is very slow, and in my experience not very useful when used against a full sized image, because it is so slow.
-However it is probably the best way to get a idea of just how similar two images are.
+This is very slow, and, in my experience, not very useful when used against a full sized image, because it is so slow.
+However, it is probably the best way to get an idea of just how similar two images are.
 
 #### Image Classification
 
 In my attempts to compare images I have found that Color, Cartoon-like, and Sketches all compare very differently to each other.
 
-Line drawings and gray-scale images especially tends to have smaller differences that color images, with just about every comparison method.
-Basically as the colors are all in a line any color metric tends to place such images 3 times closer together (1 dimentional colorspace verses a 3 dimentional colorspace)
+Line drawings and gray-scale images especially tend to have smaller differences than color images, with just about every comparison method.
+Basically, as the colors are all in a line, any color metric tends to place such images 3 times closer together (1 dimensional colorspace versus a 3 dimensional colorspace)
 
-Basically this means that separating your images into at least these two groups can be a very important first step in any serious attempt at finding duplicate or very similar images.
+Basically, this means that separating your images into at least these two groups can be a very important first step in any serious attempt at finding duplicate or very similar images.
 
-Other major classifications or image types can also make comparing images easier, just by reducing the number of images your are comparing against.
+Other major classifications of image types can also make comparing images easier, just by reducing the number of images your are comparing against.
 
 See Image classification below.
 
@@ -811,40 +812,40 @@ See Image classification below.
 
 You have a program create (in memory) lots of small thumbnails (say 64x64 pixels) of images to compare looking for duplicates, which you proceed to do by direct comparison.
 
-It is typically the first thing that people (myself included) attempt to do, and in fact this is the technique most image comparing programs (such as photo handling software) does.
+It is typically the first thing that people (myself included) attempt to do, and in fact this is the technique most image comparing programs (such as photo handling software) use.
 
-In fact this works well and does find images that exactly match.
-Also with a little blur, and loosing of the difference threshold, it can even find images that have had been been slightly cropped, and resized
+In fact, this works well and does find images that exactly match.
+Also, with a little blur, and loosening of the difference threshold, it can even find images that have been been slightly cropped, and resized.
 
-However attempting to store in memory 10,000 such thumbnails will often cause a normal computer to start thrashing, becoming very slow.
-Alternatively storing all those thumbnails (unless the program does this for user viewing reasons) uses a lot of disk space.
+However, attempting to store in memory 10,000 such thumbnails will often cause a normal computer to start thrashing, becoming very slow.
+Alternatively, storing all those thumbnails (unless the program does this for user viewing reasons) uses a lot of disk space.
 
 One method of improving the disk thrashing problem, is to only have a smaller number of images in memory.
 That is by comparing images in groups, rather than one image to all other images.
 A natural grouping is by directory, and comparing each directory of images with other directories of images.
 
-In fact this is rather good, as images tend to be grouped together, and this group of images will often match a similar group.
+In fact, this is rather good, as images tend to be grouped together, and this group of images will often match a similar group.
 Outputting matching images by directory pairs, is thus a bonus.
 
-Also how acceptably similar two images are depends on their image type.
-Comparing two line drawings needs to have very small 'threshold' to discount images that different, while comparing images with large areas of color often needs a much larger threshold to catch similar images that were cropped.
+Also, how acceptably similar two images are depends on their image type.
+Comparing two line drawings needs to have very small 'threshold' to discount images that differ, while comparing images with large areas of color often needs a much larger threshold to catch similar images that were cropped.
 
 Real world images have a bigger problem in that a texture can produce a very serious additive difference between images that has a very slight offset.
-Because of this you may need to simply such images, into general areas of color, either by using median filters, blurring, color reduction, or color segmentation.
-After such a process a real world image, generally can be compares in a similar way to cartoons.
+Because of this, you may need to simplify such images, into general areas of color, either by using median filters, blurring, color reduction, or color segmentation.
+After such a process a real world image, generally can be compared in a similar way to cartoons.
 
 #### Image Metrics
 
-Create a small metric for each image is a linear ordered (O) operation.
+Creating a small metric for each image is a linear ordered (O) operation.
 While comparing all images with all other images is a squared ordered (O^2) operation.
 
-A metric is not ment to actually find matching images, but group similar (likely matching) images in such a way that you can do a more intensive comparison on smaller groups.
-As such any metric comparison should be lenient, and accept images that have a low probably (but still a probably) of a match.
-But it should not so lenient as to include too many miss-matches.
+A metric is not meant to actually find matching images, but group similar (likely matching) images in such a way that you can do a more intensive comparison on smaller groups.
+As such, any metric comparison should be lenient, and accept images that have a low probability (but still a probability) of a match.
+But it should not be so lenient as to include too many mismatches.
 
-Also you may like to consider multiple metrics, as some metrics may match up images that another metric may 'just miss' as they fall in different neighbouring regions (threshold miss-match).
+Also, you may like to consider multiple metrics, as some metrics may match up images that another metric may 'just miss' as they fall in different neighbouring regions (threshold mismatch).
 
-In the next section ([Metrics](#metrics)) is a number of different IM generated metrics I have experimented with, or theorized about, including: average color, predominant color, foreground background, edge colors, matrix of colors, etc.
+In the next section ([Metrics](#metrics)) are a number of different IM generated metrics I have experimented with, or theorized about, including: average color, predominant color, foreground background, edge colors, matrix of colors, etc.
 
 Günter Bachelier, has also reported the possibilities of using more exotic metrics for image comparison, such as: Fourier descriptors, fractal dimensions, convex areas, major/minor axis length and angles, roundness, convexity, curl, solidity, shape variances, direction, Euler numbers, boundary descriptors, curvature, bending energy, total absolute curvature, areas, geometric centrum, center of mass, compactness, eccentricity, moments about center, etc, etc.
 
@@ -859,7 +860,7 @@ The metrics of two images (or the actual images) can be compared using a number 
 -   Direct Threshold, or Maximum Difference, (Chebyshev Distance)
     Just compare images by the largest difference in any one metric.
     The threshold will produce a hyper-cube of similar images in the multi-dimensional metric space.
-    Of course the image difference is only based on one metric and not over all metrics.
+    Of course, the image difference is only based on one metric and not over all metrics.
 -   Average Difference (Mean Distance, Averaged Manhattan Distance)  
     Sum all the differences and optionally divided by the number of metrics.  
     This is also known as the Manhattan Distance between two metrics, as is is equivalent to the distance you need to cover to travel in a city grid.
@@ -869,7 +870,7 @@ The metrics of two images (or the actual images) can be compared using a number 
     The value tends to be larger when more metrics are involved. However, one metric producing a big difference, tends to contribute more than the other metrics. A threshold produces a spherical volume in metric space.
 -   Mathematical Error/Data Fit or (Moment of Inertia???)  
     Sum all squares of all differences, then get the square root  
-    This is more typically used to calculate how close a mathematically curve fits a specific set of data, but can be used to compare image metrics too.  
+    This is more typically used to calculate how close a mathematical curve fits a specific set of data, but can be used to compare image metrics too.  
     This is seems to provide the best non-vector distance measure.
 -   Vector Angle  
     Find the angle between the two lines from the center of the vector space created by the images metric.
@@ -893,36 +894,36 @@ After the computer has finished with its attempts to find matching images, it is
 Presenting matches to the user can also be a difficult task, as they will probably want the ability to...
 
 -   See the images side-by-side
--   Flick very very quickly between two images, at their original size, and optionally a common 'scaled' size.
+-   Flick very, very quickly between two images, at their original size, and optionally a common 'scaled' size.
 -   Flick between, or overlay, differently scaled and translated images.
     To try to match up the images.
 -   See other images in the same directory (source) or prehaps the same cluster (other near matches) as the matching image, so as to deal with a whole group rather than each image individually.
 -   Rename, Move, Replace, Delete, Copy the Images between the two (or more) directories, to sort out the images, and reject others.
 -   and so on...
 
-Currently I group matches into sets and use a combination of programs to handle them under the users control.
+Currently, I group matches into sets and use a combination of programs to handle them under the user's control.
 These programs include IM's "`display`" and "`montage`", as well as image viewers "`XV`" and "`GQview`".
 
-However I am open to other suggestions of programs that can open two or more directories simultaneously, and display collections or image groups from multiple directories.
-Remote or control by other programs or scripts can be vital, as it allows the image groups to be setup and presented in the best way for the user to look at and handle.
+However, I am open to other suggestions of programs that can open two or more directories simultaneously, and display collections or image groups from multiple directories.
+Remote control by other programs or scripts can be vital, as it allows the image groups to be setup and presented in the best way for the user to look at and handle.
 
 No program has yet met my needs.
 
-For example "`gqview`" has collections, and a single directory view, but does not allow multiple directory views, or remote / command line control of the presentation.
-However the collections do not show what directory each image is from, or flip the single directory view to some other directory.
+For example, "`gqview`" has collections, and a single directory view, but does not allow multiple directory views, or remote / command line control of the presentation.
+However, the collections do not show what directory each image is from, or flip the single directory view to some other directory.
 It also has no remote program control.
 
-On the other hand the very old "`xv`" does allow multiple directory views (its using multiple 'visual schnauzer' windows), and a collection list in its control window, but only one image can be viewed at a time, and only one directory can be opened and positioned from its command line.
-Of course it also has no remote control.
+On the other hand, the very old "`xv`" does allow multiple directory views (its using multiple 'visual schnauzer' windows), and a collection list in its control window, but only one image can be viewed at a time, and only one directory can be opened and positioned from its command line.
+Of course, it also has no remote control.
 
 These are the best human verification programs I have found, which I use a script to setup and launch for each image group, matching pairs, or all group matched images.
 But none are very satisfactory.
 
-A light table and associated software seems to me to be the better method of sorting out images, but for that you need larger touch sensitive screeens, and there in lies great expense.
+A light table and associated software seems to me to be the better method of sorting out images, but for that you need larger touch sensitive screeens, and therein lies great expense.
 
 #### Cross-type Image Comparison
 
-One of the harder things I would like to do is find images that were created from another image.
+One of the harder things I would like to do, is find images that were created from another image.
 For example, I would like to match up a line drawing that someone else has colored in, or painted, to produce cartoon or even ultra realistic images.
 A background may also have been added.
 
@@ -948,37 +949,37 @@ Mail me your ideas!!!
 
 ## Sorting Images by Type {#type_general}
 
-Determining what type of image is important as most methods of comparing images only work for a specific type of image.
-It is no good comparing a image of text against a artists sketch, for example.
-Nor is it useful to use a color image comparison method on image which is almost pure white (sketch).
+Determining the type of an image is important, since most methods of comparing images only work for a specific type of image.
+It is no good comparing an image of text against an artist's sketch, for example.
+Nor is it useful to use a color image comparison method on an image which is almost pure white, such as a sketch.
 
-Usually the first thing to do when comparing images is to determine what type of image, or 'colorspace' the image uses.
+Usually, the first thing to do when comparing images is to determine what type of image, or 'colorspace' the image uses.
 Basic classifications of images can include...
 
--   Black and white line drawing or text image.
--   Gray-scale artists sketch.
--   Cartoon like color image with large areas of solid colors.
--   A real life image with areas of shaded colors
--   Very dark, almost all black images.
--   Very light, almost all white images.
--   Images consisting of two basic colors (other than black and white).
--   Image contains some annotated text or logo overlay.
+-   black and white line drawing or text image
+-   gray-scale artist's sketch
+-   cartoon-like color image with large areas of solid colors
+-   real life image with areas of shaded colors
+-   very dark, almost all black images
+-   very light, almost all white images
+-   images consisting of two basic colors - other than black and white
+-   images containing some annotated text or logo overlay.
 
 After you have basic categories you can also attempt to sort images, using various image metrics, such as...
 
--   Average color of the whole image
+-   average color of the whole image
 -   predominant color in image
--   Foreground/Background color of image.
+-   foreground/background color of image.
 
 What is worse, is that JPEG, or resized images are often also color distorted, making such classifications much more difficult as colors will not be quite as they should be.
-Greys will not be pure greys, and lines may not sharp and clear.
+Greys will not be pure greys, and lines may not be sharp and clear.
 
 A discussion on sorting images by type is on the IM Users Forum...
 [How to check image color or black and white](../forum_link.cgi?f=1&t=19580).
 
 ### Gray-scale Images {#type_greyscale}
 
-Basically if you do a comparison difference of the image, against a gray-scaled version of itself, it should produce very little difference if it is gray-scale, and quite a lot of differences if it is colorful.
+Basically, if you do a comparison difference of the image, against a gray-scaled version of itself, it should produce very little difference if it is gray-scale, and quite a lot of differences if it is colorful.
 
     Saturation Test
 
@@ -989,9 +990,9 @@ Basically if you do a comparison difference of the image, against a gray-scaled 
         granite:  avg=0.0343691 peak=0.062501
 
       The numbers are normalized to a 0 to 1 range.  As you can see the "rose" is
-      very colorful, with a strong peak, and a average of roughly half the
-      staturation range.  The "granite" image however have very low saturation and
-      low peak value. Though it is not pure greyscale it is close to it.
+      very colorful, with a strong peak, and an average of roughly half the
+      staturation range.  The "granite" image however has very low saturation and
+      low peak value. Though it is not pure greyscale, it is close to it.
 
       A low average and high peak will indicate small patches of strong color.
       Thresholding the saturation channel can generate a mask of the color area.
@@ -1025,7 +1026,7 @@ Basically if you do a comparison difference of the image, against a gray-scaled 
 
 ### Pure Black and White images {#type_bw}
 
-To see if an image is near pure black and white image, with little in the way of extra colors or greys (due to anti-aliasing), we can make a novel use of the "`-solarize`" option (See the IM example on [Solarize](../color_mods/#solarize)).
+To see if an image is a near pure black and white image, with little in the way of extra colors or greys (due to anti-aliasing), we can make a novel use of the "`-solarize`" option (See the IM example on [Solarize](../color_mods/#solarize)).
 
 Applying this operation onto any image results in any bright colors becoming dark color (being negated).
 As such any near white colors will become near black colors.
@@ -1051,8 +1052,7 @@ Thus this image must be mostly pure black and white, with very few colors or mid
 For general gray-scale and color images, the 'mean' will be much larger, and generally the 'standard deviation' smaller than the mean.
 When that happens it means the solarized image has very little near pure black in it.
 That is very few pure black or white colors are present.
-
-Lets repeat this test using the built in granite image.
+Let's repeat this test using the built-in granite image.
 
 ~~~
 convert granite: granite.jpg
@@ -1070,41 +1070,41 @@ identify -verbose -alpha off granite_bw_test.png | \
 Note how the 'mean' is now much larger toward the middle of the color range, with a 'standard deviation' that is much smaller than the size of the 'mean'.
 
 As of IM v6.4.8-3 you will also see two other statistic values that can be helpful in determining the type of image.
-Both '[Kurtosis](http://en.wikipedia.org/wiki/Kurtosis)' and '[Skewness](http://en.wikipedia.org/wiki/Skewness)', are is relatively large (and positive) in the first Black and White image also reflects the fact that very few grays are involved when compared to a Gray image.
-However 'mean' vs 'standard divination' is still probably the better indicator for comparison purposes.
+Both '[Kurtosis](http://en.wikipedia.org/wiki/Kurtosis)' and '[Skewness](http://en.wikipedia.org/wiki/Skewness)', are relatively large (and positive) in the first Black and White image which also reflects the fact that very few grays are involved when compared to a Gray image.
+However 'mean' vs 'standard deviation' is still probably the better indicator for comparison purposes.
 
 Note that this comparison does not differentiate between 'black on white', or 'white on black' but once you know it isn't a gray-scale image a simple check will tell you what the background color really is.
 
 ### Text vs Line Drawing {#type_text_vs_line}
 
-If you have a almost pure black and white image then you can try to see if the image contents could be classified as either text, or a line drawing.
+If you have an almost pure black and white image then you can try to see if the image contents could be classified as either text, or a line drawing.
 
 Text will have lots of small disconnected objects, generally grouped into horizontal lines.
-On the other hand line drawings should have everything mostly connected together as a whole, and involving many different angles.
+On the other hand, line drawings should have everything mostly connected together as a whole, and involving many different angles.
 
-Note that cartoon like color images could also be turned into a line drawing for simpler image comparing, so a line drawing comparison method would be a useful thing to have.
+Note that cartoon-like color images could also be turned into a line drawing for simpler image comparing, so a line drawing comparison method would be a useful thing to have.
 Anyone?
 
 A line drawing image may also be better for matching images with shifted positions, and or rotations.
 Anyone?
 
-To find out more about the text, a number of techniques has been discussed in the IM forums, [Check if image contains text](../forum_link.cgi?f=1&t=21263).
+To find out more about the text, a number of techniques have been discussed in the IM forums, [Check if image contains text](../forum_link.cgi?f=1&t=21263).
 
 ### Real Life vs Cartoon Like {#type_real_vs_cartoon}
 
-Basically cartoons have very specific blocks of color with sharp bordered regions, often made sharper by using a separating black line.
+Basically, cartoons have very specific blocks of color with sharp bordered regions, often made sharper by using a separating black line.
 They also usually have a minimal gradient or shading effects.
 Real life images however have lots of soft edging effects, color gradients, and textures, and use lots of different colors.
 
-This is of course not always true.
-A real life image could have a very cartoon like quality about it, especially is a very high contrast is used, and some modern cartoons are so life-like that it can be difficult to classify them as cartoons or animation.
+This is, of course, not always true.
+A real life image could have a very cartoon-like quality about it, especially if a very high contrast is used, and some modern cartoons are so life-like that it can be difficult to classify them as cartoons or animation.
 
-Generally the major difference between a real life image and a cartoon is textures and gradients.
-As such to determine what type of image it is requires you to compare the image, to the same image with the fine scale texture removed.
+Generally, the major differences between real life images and cartoons are textures and gradients.
+As such, to determine what type of image it is requires you to compare the image, to the same image with the fine scale texture removed.
 A large difference means the image is more 'realistic' and 'real world' like, rather than than 'cartoonish' or 'flat'.
 
-Also remember a line drawing, artist sketch, and text can also be very cartoon like in style, but have such a fine texture and detail to it that the above could think of the image as real world.
-As such line drawings and sketches should be separated out before hand.
+Also, remember a line drawing, artist sketch, and text can also be very cartoon-like in style, but have such a fine texture and detail to it that the above could think of the image as real world.
+As such line drawings and sketches should be separated out beforehand.
 
 > Does anyone have a suggestion on how to do this?
 Email me.
@@ -1115,14 +1115,13 @@ Jim Van Zandt offers this solution...
 -   sort by color
 -   write out the pixel count for every color
 -   sort by pixel count
--   Work your way through the list until you have accounted for half the pixels in the image.
--   If \#pixels &gt;&gt;&gt; \#colors then it's cartoon like.
+-   work your way through the list until you have accounted for half the pixels in the image.
+-   if \#pixels &gt;&gt;&gt; \#colors then it's cartoon-like.
 
 The initial section can be classed as histogram.
 See the "`histogram:`" examples.
   
- *If you have created some sort of image classification scheme..
-Even if only roughly, please let us know your results, so others (including myself) can benefit.*
+*If you have created some sort of image classification scheme - even if only roughly -  please let us know your results, so others, including myself, can benefit.*
 
 ------------------------------------------------------------------------
 
@@ -1132,10 +1131,10 @@ Here are notes and information on more specific image determination techniques.
 
 ### Bad Scan or Printouts
 
-In the real world, things never work quit as perfectly as you would like.
+In the real world, things never work quite as perfectly as you would like.
 Scanners have broken sensors and printer drums have scratches.
-Both of these problems generally result in scans and printouts containing long vertical lines.
-Determining if an image has these vertical lines is however fairly easy.
+Both of these problems generally result in scans and printouts containing long, vertical lines.
+Determining if an image has these vertical lines is, however, fairly easy.
 
 The idea is to average the pixels of all the rows in an image together.
 Any 'fault' will appear as a sharp blip in the final pixel row the number of which you can count using a 'threshold histogram' of the pixel row.
@@ -1153,7 +1152,7 @@ When you have determined and removed such 'bad lines' from a fax, printout, or s
 ### Blank Fax
 
 First you will need to "`-shave`" off any headers and footers that a fax may have added to a page.
-You can then either to a 'threshold histogram' (see previous) to see how many individual black pixels there are.
+You can then either make a 'threshold histogram' (see previous) to see how many individual black pixels there are.
 
     FUTURE -- image example needed for testing
         convert blank_fax.png -threshold 50% -format %c histogram:info:-
@@ -1164,15 +1163,15 @@ Or you can do a [Noisy Trim](../crop/#trim_blur) to see if the image actually co
 
 ### Spammed Images
 
-A spammed image will generally show a predominant pure color spike in the images color histogram.
+A spammed image will generally show a predominant pure color spike in the image's color histogram.
 A check on the color in the image will usually show it to be in one of the corners of the image.
 
-However this will not work with cartoon like images.
+However this will not work with cartoon-like images.
 
 ### EMail Spam Images
 
 These are images designed to get past the various spam filters.
-Basically the text of the ad is hidden in an image using various colors and extra 'dirt' and other noise added to make it harder to detect.
+Basically, the text of the ad is hidden in an image using various colors and extra 'dirt' and other noise added to make it harder to detect.
 And while these are difficult to distinguish from say a logo of a company email header, they are usually also much larger than the typical email logo.
 
 One discovery technique is to use a large median filter on the image.
@@ -1182,64 +1181,64 @@ EMail spam text will generally disappear, while a logo or image will still remai
 
 ## Image Metrics, quickly finding images to compare {#metrics}
 
-A metric represents a type of 'finger print' to represent an image, in a very small amount of memory.
+A metric represents a type of 'finger-print' to represent an image, in a very small amount of memory.
 Similar images should result in a similar metric.
-Note however that a metric is not designed to actually find matching images, but to try to discount images that are definitely not a match.
-That is a good metric will let you disregard most images from further comparisons, thus reduce the amount of time needed to search all the images.
+Note, however, that a metric is not designed to actually find matching images, but to try to discount images that are definitely not a match.
+That is, a good metric will let you disregard most images from further comparisons, thus reduce the amount of time needed to search all the images.
 
 ### Average Color of an image {#metric_average}
 
-    You can use -scale to get an average color of an image, however I also suggest
-    you remove the outside borders of the image  to reduce the effect of
-    any 'fluff' that may have been added around the image.
+You can use "-scale" to get an average color of an image, however I also suggest you remove the outside borders of the image  to reduce the effect of any 'fluff' that may have been added around the image.
 
-        convert image.png  -gravity center -crop 70x70%+0+0 \
-                -scale 1x1\! -depth 8 txt:-
+~~~
+convert image.png  -gravity center -crop 70x70%+0+0 \
+	-scale 1x1\! -depth 8 txt:-
+~~~
 
-    Alternatively to get 'weighted centroid' color, based on color clustering,
-    rather than a average, you can use -colors
+Alternatively, to get 'weighted centroid' color, based on color clustering, rather than an average, you can use "-colors"
 
-        convert rose: -colors 1 -crop 1x1+0+0 -depth 8 -format '%[pixel:s]' info:-
-        rgb(146,89,80)
+~~~
+convert rose: -colors 1 -crop 1x1+0+0 -depth 8 -format '%[pixel:s]' info:-
+rgb(146,89,80)
+~~~
 
 This will generally match images that have been resized, lightly cropped, rotated, or translated.
 But it will also match a lot of images that are not closely related.
 
-The biggest problem is that this metric will generally disregard images that have been brightened, dimmed or changed the overall hue of the image.
+The biggest problem is that this metric will generally disregard images that have been brightened, dimmed or had the overall hue changed.
 
-Also while it is a great metric for color and real-world images, it is completely useless for images that are greyscale.
+Also, while it is a great metric for color and real-world images, it is completely useless for images that are greyscale.
 All such images generally get lumped together without any further clustering within the type.
 
-This in turn shows why some initial classification of image types can be vital to good image sorting and matching.
+This, in turn, shows why some initial classification of image types can be vital to good image sorting and matching.
 
 ### Predominant Color of an image {#metric_color}
 
-The predominant color of an image is a little different, instead of the average which merges the background colors with the foreground, you want to find the most common foreground color, and perhaps a percentage of how much of the image consists of that predominant color.
+The predominant color of an image is a little different, instead of the average, which merges the background colors with the foreground, you want to find the most common foreground color, and perhaps a percentage of how much of the image consists of that predominant color.
 
-As such you cannot just take a histogram of an image, as the image may use a lot of individual shades of color rather than a specific color.
+As such, you cannot just take a histogram of an image, as the image may use a lot of individual shades of color rather than a specific color.
 
-This can be done using the low level quantization function -segment, then taking a histogram.
-This has an advantage over direct use of -colors as it does not attempt to merge distant (color-wise) clusters of colors, though the results may be harder to determine.
+This can be done by using the low level quantization function "-segment", then taking a histogram.
+This has an advantage over direct use of "-colors" as it does not attempt to merge distant (color-wise) clusters of colors, though the results may be harder to determine.
 
      FUTURE example 
 
-After which a histogram will given you the amount of each of the predominant colors.
+After which a histogram will give you the amount of each of the predominant colors.
 
 However, usually the predominant color of a cartoon or line drawing is the background color of the image.
 So it is only really useful for real-life images.
 
-On the other hand, you may be able to use to discover if an image has a true background, by comparing this to the images average border color.
+On the other hand, you may be able to use this method to discover if an image has a true background, by comparing this to the image's average border color.
 
-Please note that a pictures predominant color is more likely to be more strongly influenced by the background color of the image, rather than the object of interest.
-That is usually in or near the center of the image.
+Please note that a picture's predominant color is likely to be more strongly influenced by the background color of the image, rather than the object of interest - which is usually in, or near, the center of the image.
 
 ### Border Colors {#metric_border_color}
 
-By repeatedly cropping off each of the four edges (2 to 3 pixels at most) of an image, and calculating the borders average color, you can determine if an image is framed, and to how deep.
+By repeatedly cropping off each of the four edges (2 to 3 pixels at most) of an image, and calculating the border's average color, you can determine if an image is framed, and to how deep.
 Whether there is a definite background to the image.
 Or if there is some type of sky/land or close-up/distant color separation to the overall image.
 
-By comparing the averaged side colors to the average central color of the image you can discover if the image is uniform without a central theme or subject, such as a photo of a empty landscape.
+By comparing the averaged side colors to the average central color of the image you can discover if the image is uniform without a central theme or subject, such as a photo of an empty landscape.
 
 ### Histogram - General Color Matching {#metric_histogram}
 
@@ -1247,19 +1246,19 @@ For a metric concerning the types of colors to be found in an image, a histogram
 This is done by creating an array of 'color bins' and incrementing the count of each 'bin' as the colors are found.
 
 Now I can't see you storing a large histogram for every image!
-So you will either only store the most predominant colors in the histogram or you would use a much smaller number of bin's (with more pixels in each bin).
+So you will either only store the predominant colors in the histogram or you would use a much smaller number of bins, with correspondingly more pixels in each bin.
 
 An ordinary histogram of 'color bins' does not really work very well.
 The reason is that each color will always fall into one bin.
-That is each pixel is added to each bin on an all or nothing bases without any regard to how near that color is an edge of a bin.
-This in turn does not make for a good metric.
+That is, each pixel is added to each bin on an all-or-nothing basis, without any regard to how near that color is to an edge of a bin.
+This, in turn, does not make for a good metric.
 
 One solution is to create a histogram that has overlapping bins.
-That is every color (except maybe black or white) will fall into two color bins.
-Then later when you compare images a near color will match at least one of those bins.
+That is, every color (except maybe black or white) will fall into two color bins.
+Then, later when you compare images a near color will match at least one of those bins.
 
-Another alternative is to create the histogram by having each color contribute to each 'bin' according to how close it is to the center of the bin.
-That is a color on the edge of one bin will actually share itself across two bins.
+Another, alternative is to create the histogram by having each color contribute to each 'bin' according to how close it is to the center of the bin.
+That is, a color on the edge of one bin will actually share itself across two bins.
 This will generate a sort of fuzzy, or interpolated histogram, but one that would more accurately represent an image, especially when only a very small number of color 'bins' are used.
 
 Also histograms are traditionally either just the gray scale component of an image or three separate RGB component.
@@ -1267,22 +1266,22 @@ But this is not a very good representation.
 
 You could try instead Hue, Saturation and Luminance Histograms to better represent the image.
 
-Alternatively why limit yourself to a 1 dimensional histogram.
-How about mapping the colors to a set a set of real colors across the whole color space!
-That is rather than binning just the 'red' value, why not count it in a 3-dimensional color bin (is what ever colorspace works best).
+Alternatively, why limit yourself to a 1 dimensional histogram?
+How about mapping the colors to a set of real colors across the whole color space!
+That is, rather than binning just the 'red' value, why not count it in a 3-dimensional color bin in whatever colorspace works best.
 That would generate a histogram that would truly represent the colors found within an image.
 
 Such a 3-d histogram metric could be a simple array of say 8x8x8 or 2048 bins.
 That is a 2Kbyte metric.
-A color search would then locate the correct number of near by bins, and get a interpolated count of the nearby bins.
+A color search would then locate the correct number of nearby bins, and get an interpolated count of the nearby bins.
 Which would represent the number of colors 'close' to that color within the image!
 
 ### Foreground/background Color Separation {#metric_color_separation}
 
-Using -colors you can attempt to separate the image into foreground and background parts, by reducing the image to just two colors.
+Using "-colors" you can attempt to separate the image into foreground and background parts, by reducing the image to just two colors.
 
-Using a -median filter first will remove the effect of minor details, and line edges and noise that may be in the image.
-Of course that is not very good for mostly white sketch-like images.
+Using a "-median" filter first will remove the effect of minor details, and line edges and noise that may be in the image.
+Of course, that is not very good for mostly white sketch-like images.
 
 ~~~
 convert rose: -median 5 +dither -colors 2 \
@@ -1304,8 +1303,8 @@ Which shows the red 'rose' color is the predominant foreground color.
 Note that a landscape image may separate differently in that you get a lower ground color and an upper sky color.
 As such a rough look at how the colors were separated could be very useful for image type determination.
 
-Also a picture with some text 'spam' will often show a blob of color in one corner that is far more prominent that the rest of the image.
-If found redo with 3 colors, then erase that area with the most common 'background' color found before doing your final test.
+Also a picture with some text 'spam' will often show a blob of color in one corner that is far more prominent than the rest of the image.
+If found, redo with 3 colors, then erase that area with the most common 'background' color found before doing your final test.
 
 This technique is probably a good way of separating images into classes like 'skin tone' 'greenery' 'landscape' etc.
 
@@ -1313,16 +1312,16 @@ This technique is probably a good way of separating images into classes like 'sk
 
 A three by three matrix color scheme ("`-scale 3x3\!`") is a reasonable color classification scheme.
 It will separate, and group similar images together very well.
-For example sketches (all near white), gray-scale, landscapes, seascapes, rooms, faces, etc, will all be separated into basic and similar groups (in theory).
+For example, sketches (all near white), gray-scale, landscapes, seascapes, rooms, faces, etc, will all be separated into basic and similar groups (in theory).
 
 This is also a reasonable metric to use for indexing images for generating [Photo Mosaics](http://libcaca.zoy.org/study/part7.html).
 
-The output of the NetPBM image format is particularly suited to generating such a metric, as it can output just the pixel values as text numbers.
+The NetPBM image format is particularly suited to generating such a metric, as it can output just the pixel values as text numbers.
 
 Remember this would produce a 27 dimensional result, (3x3 colors of 3 value), so a multi-dimensional clustering algorithm may be needed.
 *Do you know of a good 3d clustering program/algorithm?*
 
-For example, here is the 3 x 3 RGB colors (at depth 8) for the IM logo.
+For example, here is the 3x3 RGB colors (at depth 8) for the IM logo.
 
 ~~~
 convert logo: -scale 3x3\! -compress none -depth 8 ppm:- |\
@@ -1347,17 +1346,17 @@ convert logo: -gravity center -crop 80% -scale 3x3\! \
 Of course like the previous average color metric, this will also have problems matching up images that have been color modified, such as hue, or brightness changes.
 (See next section)
 
-Also this metric can separate line drawings within its grouping, though only in a very general way.
-Such drawing will still be grouped more by the color of the background 'paper' rather than by content, and generally need a smaller 'threshold' of similarity, than color images.
+Also, this metric can separate line drawings within its grouping, though only in a very general way.
+Such drawings will still be grouped more by the color of the background 'paper' rather than by content, and generally need a smaller 'threshold' of similarity, than color images.
 
 ### Color Difference Matrix {#metric_cdiff_matrix}
 
 The biggest problem with using the colors directly as a metric, is that you tie the image to a particular general color.
-This means any image that has been brightened or darkened, or its hue was changed, will not be grouped together.
+This means any image that has been brightened or darkened, or had its hue changed, will not be grouped together.
 
 One solution to this is to somehow subtract the predominant or average color of the image from the metric, and using a matrix of colors makes this possible.
 
-Here for example I subtract the middle or center average color from all the surrounding colors in the matrix.
+Here, for example, I subtract the middle or center average color from all the surrounding colors in the matrix.
 
 ~~~
 convert logo: -gravity center -crop 80% -scale 3x3\! -fx '.5+u-p{1,1}' \
@@ -1368,8 +1367,8 @@ convert logo: -gravity center -crop 80% -scale 3x3\! -fx '.5+u-p{1,1}' \
       32767 32767 32767 43469 41393 38587 52629 51279 48521 39500 41587 41926
       31729 34168 35867
 
-Note that I add .5 to the difference as you cannot save a negative color value in an image.
-Also the use of the slow "`-fx`" operator is acceptable as it only 9 pixels are processed.
+Note that I add 0.5 to the difference as you cannot save a negative color value in an image.
+Also the use of the slow "`-fx`" operator is acceptable as only 9 pixels are processed.
 
 Note that the center pixel ("32767 32767 32767" at the start of the second line in the above) will not change much (any change is only due to slight rounding errors), and could be removed, from the result, reducing the metric to 24 dimensions (values).
 
@@ -1389,13 +1388,13 @@ This also could be done by the metric comparator, rather than the metric generat
 The metric still separates and clusters color images very well, placing similar images very closely together, regardless of any general color or brightness changes.
 It is still sensitive to contrast changes though.
 
-This metric modification could in fact be done during the comparison process so a raw [Color Matrix Metric](#metric_color_matrix) can still be used as a standard image metric to be collected, cached and compared.
+This metric modification could, in fact, be done during the comparison process so a raw [Color Matrix Metric](#metric_color_matrix) can still be used as a standard image metric to be collected, cached and compared.
 This is what I myself am now doing for large scale image comparisons.
 
 Unlike a straight color average, you can use this metric to differentiate between different line drawing images.
-However as line drawing use a linear color scale (all the colors fall in a line in the metric space, the differences between images is roughly 1/3 that of color images.
-As such a very different threshold is needed when comparing line drawings.
-Is thus still better to separate line drawings and grayscale images from color images.
+However, as line drawings use a linear color scale (all the colors fall in a line in the metric space, the differences between images is roughly 1/3 that of color images.
+As such, a very different threshold is needed when comparing line drawings.
+It is thus still better to separate line drawings and grayscale images from color images.
 
 In other words this is one of the best metrics I have yet found for color images.
 Just be sure to determine what images are line drawings first and compare them separately using a much lower threshold.
@@ -1407,33 +1406,33 @@ Suggestions welcome.
 
 The above generates a 3x3 matrix, with the center pixel subtracted, and all the values offset to a perfect gray.
 
-However a better method is that instead of trying to save the color of the individual cells, to instead generate the differences between each cell and its neighbours (8 neighbours).
-That is instead of saving the color of the top left corner, save the difference between that corner and the top-middle, center, and left-middle.
+However, a better method is that instead of trying to save the color of the individual cells, to instead generate the differences between each cell and its neighbours (8 neighbours).
+That is, instead of saving the color of the top left corner, save the difference between that corner and the top-middle, center, and left-middle.
 
-Of course even with a small 3x3 array, you will end up with a signiture containing 12 differences, though you don't need to encode the full difference just a general difference level.
-such as equal, or large/small positive/negative difference values
+Of course, even with a small 3x3 array, you will end up with a signature containing 12 differences, though you don't need to encode the full difference just a general difference level,
+such as equal, or large/small positive/negative difference values.
 
-This is much more likely to find images that match even between images which contain wildly different colors, as the actual color play no part in the signature at all.
+This is much more likely to find images that match even between images which contain wildly different colors, as the actual color plays no part in the signature at all.
 
 The '[libpuzzle](http://libpuzzle.pureftpd.org/project/libpuzzle)' image comparison library does exactly that though it uses a 9x9 matrix, with just the center pixels of each cell being averaged together.
 It also limits itself to grayscale versions of the image.
 
 The technique is completely defined in a postscript paper, [Image Signature for Any Kind of Image](http://www.cs.cmu.edu/~hcwong/Pdfs/icip02.ps).
-The paper also goes into methods of storing that signature in a database and how to actuall perform a lookup to find of images with similar (not nessarially the same) signatures.
+The paper also goes into methods of storing that signature in a database and how to actually perform a lookup to find of images with similar, not necessarily identical, signatures.
 It is the first paper I have discovered that actually goes into detail on how to do this.
 :-)
 
 ### Perceptual Hash {#metric_perceptual_hash}
 
-Reduce the image to an 8x8 and calculate an average intensity.
+Reduce the image to an 8x8 image and calculate an average intensity.
 Each bit of the 64-bit hash is then 1 if the pixel is above the average or 0 if its less than average.
 
-To compare the similarity between two images you simply compare the bitwise hashes, bit by bit, and returning a hamming distance.
+To determine the similarity between two images you simply compare the bitwise hashes, bit by bit, and returning a hamming distance.
 The closer the hamming distance, the more similar the images are.
-Anything above 21 / 64 is considered not similar.
+Anything above 21/64 is considered not similar.
 
 The [pHash](www.phash.org) seems to use YCbCr encoding.
-Some talk about working directly with the DCT from JPEG and the most promising works with the magnitude / phase and maps it to a log polar coordinate system.
+Some talk about working directly with the DCT from JPEG and the most promising works with the magnitude/phase and maps it to a log polar coordinate system.
 
 ------------------------------------------------------------------------
 
@@ -1443,12 +1442,12 @@ Miscellaneous notes and techniques I have either not tried or did not work very 
 
 ### Segmentation Color {#segmentation}
 
-As you can see many of the above metrics use a blur/median filter followed by then color reduction techniques are basic attempts to simplify images to better allow them to be classified.
-However the [Color Quantization Operator](../quantize/#colors) is not really designed for this purpose.
-It's job is to reduce colors so as to highlight the important details of the image.
+As you can see, many of the above metrics use a blur/median filter followed by color reduction techniques as basic attempts to simplify images to better allow them to be classified.
+However, the [Color Quantization Operator](../quantize/#colors) is not really designed for this purpose.
+Its job is to reduce colors so as to highlight the important details of the image.
 
 For image comparison however we don't really want to highlight these features, but highlight areas of comparative interest.
-This is the job of a related color technique known segmentation...
+This is the job of a related color technique known as *segmentation*...
 
 ASIDE: from Leptonica: Image segmentation is the division of the image into regions that have different properties.
 
@@ -1464,17 +1463,16 @@ convert logo: -median 10 -segment 1x1 \
         +dither -scale 100x100\! segment_image.gif
 ~~~
 
-One problem is that -segment is VERY slow, and it only seems to work for larger images.
-Small images (like a rose: or a 100x100 scaled logo:) seems to result in just a single color being produced.
+One problem is that "-segment" is VERY slow, and it only seems to work for larger images.
+Small images (like a rose: or a 100x100 scaled logo:) seem to result in just a single color being produced.
 This may be a bug.
 
-Of course you can still scale the image after segmenting it, as we did above.
-that way you can store a larger number of images in memory to compare with each other.
+Of course, you can still scale the image after segmenting it, as we did above - that way you can store a larger number of images in memory to compare with each other.
 
 Also the resulting segmentation does not seem to work very well, when compared to the image segmentation algorithm that Leptonica provides.
 See [Leptonica: Color Segmentation](http://www.leptonica.com/color-segmentation.html).
 
-However an alternative to the IM segmentation, is to miss-use the color quantization function to find areas of similar color.
+However, an alternative to the IM segmentation, is to misuse the color quantization function to find areas of similar color.
 Example:
 
 ~~~
@@ -1482,14 +1480,14 @@ convert logo: -scale 100x100\! -median 3 \
         -quantize YIQ +dither -colors 3 segment_image.gif
 ~~~
 
-The disadvantage is that -color limits the number of color areas that may be present in an image, where segment tries to preserve similar areas, regardless of how many areas are really present in the image (or at least that is what it should do).
+The disadvantage is that "-color" limits the number of color areas that may be present in an image, where segment tries to preserve similar areas, regardless of how many areas are really present in the image (or at least that is what it should do).
 
 ### Colorless Edge Comparison {#edge_compare}
 
-Image color is notoriously unreliable, particularly for cartoon like images.
+Image color is notoriously unreliable, particularly for cartoon-like images.
 Different users could quite easily recolor such images, add different colors backgrounds, or even take a sketch and color it in.
 
-One way to match up such images is to some basic color reduction, as per method above, but then rather than comparing images based on the resulting color you perform an edge detection, and further processing so that only the outlines of the most important color changes are used for the metrics and comparison of the images.
+One way to match up such images is to do some basic color reduction, as per method above, but then, rather than comparing images based on the resulting color, you perform an edge detection, and further processing so that only the outlines of the most important color changes are used for the metrics and comparison of the images.
 
 For example...
 
@@ -1499,7 +1497,7 @@ convert logo: -scale 100x100\! -median 3 \
         -colorspace gray -blur 0x1   outline_image.gif
 ~~~
 
-An alternative may be to use the -lat (Local Area threshold) for edge detection, which may give you some better control...
+An alternative may be to use the "-lat" (Local Area threshold) for edge detection, which may give you some better control...
 
 ~~~
 convert logo: -scale 100x100\! -median 3 \
@@ -1510,10 +1508,10 @@ convert logo: -scale 100x100\! -median 3 \
 
 Of course for comparing you would use a line drawing comparison method.
 
-> ??? how would you compare line drawings in a workable way ???  
+> ??? How would you compare line drawings in a workable way ???  
 
 Multiply images together and see if resulting image added or reduced the intensity of the lines.
-Mis-Matching lines will become black.
+Mismatching lines will become black.
 
 ------------------------------------------------------------------------
 

--- a/compare/index.md
+++ b/compare/index.md
@@ -215,7 +215,7 @@ convert bag_frame1.gif bag_frame2.gif -compose difference -composite \
 
 [![\[IM Output\]](difference_vector_scaled.gif)](difference_vector_scaled.gif)
 
-This is actually very similar to what you would get for a "`-colorspace Gray`' difference image (as above), but it is a much more accurate representation of color difference.
+This is actually very similar to what you would get for a "`-colorspace Gray`' difference image (as above), but it is a much more accurate representation of color difference.
 
 You could leave off the second '`Pow 0.5`' modification, in which case you will get a Squared difference Image.
 
@@ -1523,9 +1523,9 @@ What has changed in fixed cameras
 
 Walter Perry &lt;gatorus13\_AT\_earthlink.net&gt; reports...
 
-The project I am working involves processing groups of 20 images sent from a surveillance camera in response to the camera sensing motion.  These cameras are at remote locations and once they detect motion the images are sent to a local server.  Once at the local server, I want to be able to "filter" out those images that do not contain what caused the event.
+The project I am working involves processing groups of 20 images sent from a surveillance camera in response to the camera sensing motion. These cameras are at remote locations and once they detect motion the images are sent to a local server. Once at the local server, I want to be able to "filter" out those images that do not contain what caused the event.
 
-I use PerlMagick to compare the first image in the series (which will always not contain anything other than the normal background) with the rest of the images.  I am getting an "average" difference for all the images and then if the individual difference is greater than the average difference I keep the image as it has something in it.
+I use PerlMagick to compare the first image in the series (which will always not contain anything other than the normal background) with the rest of the images. I am getting an "average" difference for all the images and then if the individual difference is greater than the average difference I keep the image as it has something in it.
 
 This approach works great no matter day or night or what the lighting conditions.
 I originally was trying to use just a percentage difference above the first image, but that was not too reliable and really depended on the lighting conditions.

--- a/compare/index.md
+++ b/compare/index.md
@@ -213,7 +213,7 @@ convert bag_frame1.gif bag_frame2.gif -compose difference -composite \
 
 [![\[IM Output\]](difference_vector_scaled.gif)](difference_vector_scaled.gif)
 
-This is actually very similar to what you would get for a "`-colorspace Gray`' difference image (as above), but it is much more accuriate representation of color difference.
+This is actually very similar to what you would get for a "`-colorspace Gray`' difference image (as above), but it is much more accuriate representation of color difference.
 
 You could leave of the second '`Pow 0.5`' modification in which case you will get a Squared difference Image.
 
@@ -1525,9 +1525,9 @@ What has changed in fixed cameras
 
 Walter Perry &lt;gatorus13\_AT\_earthlink.net&gt; reports...
 
-The project I am working involves processing groups of 20 images sent from a surveillance camera in response to the camera sensing motion.  These cameras are at remote locations and once they detect motion the images are sent to a local server.  Once at the local server, I want to be able to "filter" out those images that do not contain what caused the event.
+The project I am working involves processing groups of 20 images sent from a surveillance camera in response to the camera sensing motion. These cameras are at remote locations and once they detect motion the images are sent to a local server. Once at the local server, I want to be able to "filter" out those images that do not contain what caused the event.
 
-I use PerlMagick to compare the first image in the series (which will always not contain anything other than the normal background) with the rest of the images.  I am getting an "average" difference for all the images and then if the individual difference is greater than the average difference I keep the image as it has something in it.
+I use PerlMagick to compare the first image in the series (which will always not contain anything other than the normal background) with the rest of the images. I am getting an "average" difference for all the images and then if the individual difference is greater than the average difference I keep the image as it has something in it.
 
 This approach works great no matter day or night or what the lighting conditions.
 I originally was trying to use just a percentage difference above the first image, but that was not too reliable and really depended on the lighting conditions.

--- a/compose/index.md
+++ b/compose/index.md
@@ -625,11 +625,11 @@ Something that can be very useful.
 
 [![\[IM Output\]](gradient_op_multiply.png)](gradient_op_multiply.png)
 
-### Multiply   ( ![](../img_www/multiply.gif) ) (make white transparent for diagrams/text) {#multiply}
+### Multiply ( ![](../img_www/multiply.gif) ) (make white transparent for diagrams/text) {#multiply}
 
 Is one of the more useful, but under-rated, compose methods and is a simple multiply of the two images.
 
-Its formula is of course:   $Src*Dest$
+Its formula is of course:  $Src*Dest$
 
 This means that if one of the images is pure white, the result will be the other image.
 On the other hand if one image is black the result will be black.
@@ -675,7 +675,7 @@ Or it can be used on satellite cloud images before overlaying the result on a ge
 This is almost exactly like '`Multiply`' except both input images are negated before the compose, and the final result is also then negated again to return the image to normal.
 In technical terms the two methods are 'Duals' of each other.
 
-That makes its formula:   $1-(1-Src)*(1-Dest)$
+That makes its formula:  $1-(1-Src)*(1-Dest)$
 
 This means that if one of the images is pure black, the result will be the other image.
 On the other hand if one image is white the result will be white.
@@ -723,12 +723,12 @@ However as it can only darken images, it is not as useful as the '`HardLight`' m
 
 [![\[IM Output\]](gradient_op_divide.png)](gradient_op_divide.png)
 
-### Divide, Divide\_Dst, Divide\_Src   ( ![](../img_www/divide.gif) ) (removing shading effects) {#divide}
+### Divide, Divide\_Dst, Divide\_Src  ( ![](../img_www/divide.gif) ) (removing shading effects) {#divide}
 
 The two images are divided from each other.
 Which image divides which depends on if '`Divide_Src`' or '`Divide_Dst`' is applied.
 
-The formula for '`Divide_Dst`' is $\frac{Src} {Dest}$ and for '`Divide_Src`' is   $\frac{Dest} {Src}$
+The formula for '`Divide_Dst`' is $\frac{Src} {Dest}$ and for '`Divide_Src`' is  $\frac{Dest} {Src}$
 
 Due to the order of images normally defined in image composition, and the "`composite` command, the original method '`Divide` meant...
 
@@ -797,7 +797,7 @@ See '`Color_Dodge`' for equivalences.
 
 [![\[IM Output\]](gradient_op_plus.png)](gradient_op_plus.png)
 
-### Plus   ( ![](../img_www/plus.gif) ) (Add colors together to form a blend) {#plus}
+### Plus ( ![](../img_www/plus.gif) ) (Add colors together to form a blend) {#plus}
 
 Add the colors of the overlay to the background.
 In essence causing the two images to blend together equally.
@@ -2503,7 +2503,7 @@ convert gradient_dst.png gradient_src.png \
 
 Similarly you can generate other compose methods such as...
 
-| Compose Method | Mathematics Args |
+| Compose Method | Mathematics Args |
 |:---------------|:-----------------|
 | `Multiply`     | `1,0,0,0`        |
 | `Screen`       | `-1,1,1,0`       |

--- a/distorts/affine/index.md
+++ b/distorts/affine/index.md
@@ -184,8 +184,8 @@ If you want to calculate the correct affine matrix to do proper unscaled rotatio
 
 $$
 \begin{array}{cc}
-sx =  cos(α) & rx = sin(α) \\
-ry = -sin(α) & sy = cos(α) \\
+{sx} =  \cos({\alpha}) & {rx} = \sin({\alpha}) \\
+{ry} = -\sin(\alpha) & {sy} = \cos(\alpha) \\
 \end{array}
 $$
 

--- a/distorts/index.md
+++ b/distorts/index.md
@@ -1691,7 +1691,7 @@ The result is a ground consisting of random noise that gets smoother and more bl
 It gives a natural feeling of depth, without any specific repeating pattern.
 
 Here I repeated the above but with a pure black and white source image.
-However I am not interested in the actual distorted image, only the [Virtual Pixel](../misc/#virtual-pixel) '`random`' pattern that was generated, so I changed what part of the 'distorted image space' I am looking at, by using a special '`-set option:distort:viewport`' setting.
+However I am not interested in the actual distorted image, only the [Virtual Pixel](../misc/#virtual-pixel) '`random`' pattern that was generated, so I changed what part of the 'distorted image space' I am looking at, by using a special '`-set option:distort:viewport`' setting.
 This setting overrides the normal size and location of the area of distorted space being viewed.
 In this case an area only containing virtual pixels, and not the distorted image.
 
@@ -2306,7 +2306,7 @@ By default it will curve the given image into a perfectly circular arc over the 
 
 To do this it takes up to four arguments.
 
-` arc_angle   rotate_angle   top_radius   bottom_radius`
+` arc_angle rotate_angle top_radius bottom_radius`
 
 However only the "`arc_angle`" is required, the other arguments are optional, and can be added as needed, in the sequence given.
 

--- a/draw/index.md
+++ b/draw/index.md
@@ -1095,7 +1095,7 @@ This however is not a easy document to read as it is really for programmers, not
 -   Uppercase letters specify the final point absolute coordinates.
 -   Lowercase letters are relative to the end point of the previous component.
 
-    > For example: "` M 1,2   l 3,4   l 2,-4 `" is the same as "` M 1,2   L 4,6   L 6,2 `".
+    > For example: "` M 1,2 l 3,4 final 2,-4 `" is the same as "` M 1,2 L 4,6 L 6,2 `".
     >
     > That is 3,4 was added to 1,2, to draw a line to 4,6.
     >
@@ -1105,9 +1105,9 @@ This however is not a easy document to read as it is really for programmers, not
     However for curves, I recommend you add the function letters anyway for ease of reading.
 -   Repeated arguments of "`M`" or "`m`" are treated as "`L`" or "`l`" respectively.
 
-    > For example: "` M 1,2   3,4   5,6 `" is the same as "` M 1,2   L 3,4   L 5,6 `"
+    > For example: "` M 1,2 3,4 5,6 `" is the same as "` M 1,2 L 3,4 L 5,6 `"
     >
-    > And : "` m 1,2   3,4   2,-4 `" is the same as "` m 1,2   l 3,4   l 2,-4 `"
+    > And : "` m 1,2 3,4 2,-4 `" is the same as "` m 1,2 l 3,4 l 2,-4 `"
 
 -   For cubic bezier all points (control and end knot points) are given relative to the end point of the previous path component.
 

--- a/draw/index.md
+++ b/draw/index.md
@@ -1095,7 +1095,7 @@ This however is not a easy document to read as it is really for programmers, not
 -   Uppercase letters specify the final point absolute coordinates.
 -   Lowercase letters are relative to the end point of the previous component.
 
-    > For example: "` M 1,2 l 3,4 final 2,-4 `" is the same as "` M 1,2 L 4,6 L 6,2 `".
+    > For example: "` M 1,2 l 3,4 l 2,-4 `" is the same as "` M 1,2 L 4,6 L 6,2 `".
     >
     > That is 3,4 was added to 1,2, to draw a line to 4,6.
     >

--- a/files/index.md
+++ b/files/index.md
@@ -863,7 +863,7 @@ convert  rose:  -verbose  info:  | head
 > It also causes some operators like "`-colors`" to output additional information.
 > As such you may like to turn it off again after using it with either "`-identify`" or the "`info:`" format.
 >
-> For example    "`-verbose -write       info:image_info.txt +verbose`" *   or   * "`-verbose -identify +verbose`" *.*
+> For example "`-verbose -write       info:image_info.txt +verbose`" * or * "`-verbose -identify +verbose`" *.*
 >
 > ![](../img_www/warning.gif)![](../img_www/space.gif)
 > Scripted reading of the output from any form of "`identify`", should do so in a case in-sensitive way.

--- a/filter/index.md
+++ b/filter/index.md
@@ -296,22 +296,15 @@ convert checks_10.gif -filter point -resize 5x5  checks_point-5.gif
 ~~~
 
 [![\[IM Output\]](checks_10_mag.gif)](checks_10.gif)  
- 
-  
 ![==&gt;](../img_www/right.gif)
-  
 [![\[IM Output\]](checks_point-1_mag.gif)](checks_point-1.gif)  
 Point-1
-  
 [![\[IM Output\]](checks_point-2_mag.gif)](checks_point-2.gif)  
 Point-2
-  
 [![\[IM Output\]](checks_point-3_mag.gif)](checks_point-3.gif)  
 Point-3
-  
 [![\[IM Output\]](checks_point-4_mag.gif)](checks_point-4.gif)  
 Point-4
-  
 [![\[IM Output\]](checks_point-5_mag.gif)](checks_point-5.gif)  
 Point 50%
 
@@ -346,22 +339,15 @@ convert checks_10.gif -filter box -resize 5x5  checks_box-5.gif
 ~~~
 
 [![\[IM Output\]](checks_10_mag.gif)](checks_10.gif)  
- 
-  
 ![==&gt;](../img_www/right.gif)
-  
 [![\[IM Output\]](checks_box-1_mag.gif)](checks_box-1.gif)  
 Box-1
-  
 [![\[IM Output\]](checks_box-2_mag.gif)](checks_box-2.gif)  
 Box-2
-  
 [![\[IM Output\]](checks_box-3_mag.gif)](checks_box-3.gif)  
 Box-3
-  
 [![\[IM Output\]](checks_box-4_mag.gif)](checks_box-4.gif)  
 Box-4
-  
 [![\[IM Output\]](checks_box-5_mag.gif)](checks_box-5.gif)  
 Box 50%
 
@@ -1035,7 +1021,7 @@ with minimal [blocking](#blocking) and [ringing](#ringing) effects and no [blurr
 > That is, the default 2.0 support Lagrange filter, generates a Lagrange filter of order 3 (order = support × 2 - 1, thus support=2.0 =&gt; Lagrange-3 filter).
 > This is why you can really only use a setting in half-integer sizes.
 >
-> As such, to get a Lagrange order 4 filter you would use the option   `-define filter:support=2.5`
+> As such, to get a Lagrange order 4 filter you would use the option `-define filter:support=2.5`
 
 [![\[IM Output\]](graph_lagrange_windowed.gif)](graph_lagrange_windowed.jpg) With larger [support](#support) settings, the '`Lagrange`' filter generates [Windowed Sinc Filters](#windowed) without needing a complex trigonometric function calculation, or even additional windowing functions.
 The larger the support setting the closer the filter emulates a *Sinc()* function, but also the slower the calculation - see graph of larger support Lagrange filters left.

--- a/formats/index.md
+++ b/formats/index.md
@@ -1686,7 +1686,7 @@ convert rgb_image.jpg -profile CMYK_PROFILE cmyk_image.jpg
 ~~~
 
 This will convert using perceptive intent, the default (see [Color Space Conversion](http://www.cambridgeincolour.com/tutorials/color-space-conversion.htm) for an detailed explanation on rendering intents).
-Because the results via perceptive intent can differ greatly depending on the software that was used to create the ICC profiles, you can use "`-black-point-compensation`" along with "`-intent relative`" to get a result that is somewhat nearer to what one might expect.
+Because the results via perceptive intent can differ greatly depending on the software that was used to create the ICC profiles, you can use "`-black-point-compensation`" along with "`-intent relative`" to get a result that is somewhat nearer to what one might expect.
 
 ~~~
 convert rgb_image.jpg  -intent relative -black-point-compensation \
@@ -2827,9 +2827,9 @@ That makes it useful for seeing the working image as it currently stands and is 
 All the other images in the multi-image file format are the images that are used to generate that first combined image.
 That is the individual working layer images, the user was working on at the time it was saved.
 
-So if you just want the 'final' image I suggest you append a " `'[0]'` " to the input filename to junk the working images, and just use the all-in-one first image.
+So if you just want the 'final' image I suggest you append a " `'[0]'` " to the input filename to junk the working images, and just use the all-in-one first image.
 
-However if you plan to work with the individual layer images then use " `'[1--1]'` " to skip the first image.
+However if you plan to work with the individual layer images then use " `'[1--1]'` " to skip the first image.
 If no extra layer images are found than the first image will be returned instead.
 I do NOT recommend using "`-delete 0`" as that will return no images at all if no layer images follow that first image.
 

--- a/fourier/fft_math/index.md
+++ b/fourier/fft_math/index.md
@@ -338,7 +338,7 @@ convert convolve_kernel.png -roll -64-64 +fft \
 
 ------------------------------------------------------------------------
 
-## FFT Division   ( ![](../../img_www/fft_divide.gif) ) {#divide}
+## FFT Division ( ![](../../img_www/fft_divide.gif) ) {#divide}
 
 Here we use division to remove or de-convolve (for want of a better word) the blur that was added to the above image.
 It is basically exactly the same except that the 'normalized' convolution kernel is divided from the main image.

--- a/index.md
+++ b/index.md
@@ -95,7 +95,7 @@ For more advanced users
   
 Older version warnings
 
-**Test Image Storage Directories...**   [Small Images](images/) ([image display](images/INDEX.html)),     [Photographs](img_photos/) ([fancy index](img_photos/INDEX.html)).
+**Test Image Storage Directories...** [Small Images](images/) ([image display](images/INDEX.html)), [Photographs](img_photos/) ([fancy index](img_photos/INDEX.html)).
 
 ------------------------------------------------------------------------
 
@@ -336,7 +336,7 @@ Also to Nicolas Robidoux, an expert in digital image processing, for reworking t
 And finally to the many users of ImageMagick who, had allowed others to see the IM commands they use as part of some project, either on the forums, or on the web.
 You are all to be commended on your willingness and openness to share your findings.
 
-Well enough "Yadda, yadda, yadda."   Go look at some of the examples.
+Well enough "Yadda, yadda, yadda." Go look at some of the examples.
 
 ---
 created: 7 November 2003  

--- a/layers/index.md
+++ b/layers/index.md
@@ -709,7 +709,7 @@ convert {balloon,castle,eye,eyeguy,ghost,hand_point,medical}.gif \
 
 [![\[IM Output\]](image_circle.png)](image_circle.png)
 
-The key to the above example is the "`-set page`" operation that uses the normalized image index (the [FX Expression](http://www.imagemagick.org/script/fx.php) '`t/n`' ) to create a value from 0.0 to not quite 1.0 for each individual image.
+The key to the above example is the "`-set page`" operation that uses the normalized image index (the [FX Expression](http://www.imagemagick.org/script/fx.php) '`t/n`') to create a value from 0.0 to not quite 1.0 for each individual image.
 This value is then mapped to position the image (by angle) in a circle of 80 pixels radius, using [FX Expressions as a Percent Escape](../transform/#fx_escapes).
 
 The position calculated is of the top-left corner of the image (not its center, though that is a simple adjustment), which is then [Merged](#merge) to generate a new image.
@@ -951,7 +951,7 @@ The above program seems complex, but is actually quite straightforward.
 
 The first image is used to start a accumulating stack of images (image index \#0).
 
-Note we could have actually started with a single transparent pixel ("`-size 1x1 xc:none`"), if you don't want to use that first image to initialize the stack.
+Note we could have actually started with a single transparent pixel ("`-size 1x1 xc:none`"), if you don't want to use that first image to initialize the stack.
 
 Now to add a new image to the bottom of the image stack, we apply the same set of operations, each time...
 

--- a/lens/index.md
+++ b/lens/index.md
@@ -92,9 +92,9 @@ The file can be examined by the use of a text editor or an XML viewer:
 </lens>
 ~~~
 
-As can be taken from the camera's technical data sheet, the zoom range of the Nikon Coolpix 995 is 8.2 – 31.0 mm, corresponding to 38 – 152 mm for 35 mm film cameras.
+As can be taken from the camera's technical data sheet, the zoom range of the Nikon Coolpix 995 is 8.2 – 31.0 mm, corresponding to 38 – 152 mm for 35 mm film cameras.
 This gives a crop factor of 152 / 31 = 4.90, which roughly corresponds to the 4.843 given the XML file.
-The coefficients of the correction by barrel distortion are supplied for six focal lengths, namely 8.2 mm, 10.1 mm, 13.6 mm, 18.4 mm, 23.4 mm, 28.3 mm and 31.0 mm.
+The coefficients of the correction by barrel distortion are supplied for six focal lengths, namely 8.2 mm, 10.1 mm, 13.6 mm, 18.4 mm, 23.4 mm, 28.3 mm and 31.0 mm.
 The coefficients `a` and `c` are, for this lens, set to zero, i.e. the distortion is described only by the second-order term `b`.
 
 Note that many lenses will also have values for `a` and `c` parameters as well, and these should also be interpolated in a similar way.
@@ -199,7 +199,7 @@ $$
 {Hfov} = 2 × \arctan{ \left ( \frac{18 mm }{f} \right ) }
 $$
 
-with 18 mm being half of the width of a 35 mm negative (which measures 36 × 24 mm).
+with 18 mm being half of the width of a 35 mm negative (which measures 36 × 24 mm).
 
 Then press the button 'Optimize now!'.
 The resulting parameters 'a', 'b' and 'c' should fall below 0.01 for wide angle lenses and below 0.1 for fisheye lenses.
@@ -284,15 +284,15 @@ The white circle (indicating zero difference) results from the non-scaling restr
 ### GoPro flattening {#gopro}
 
 The GoPro camera lens produces a pronounced barrel distortion, which seems to be part of its branding.
-For instance, the GoPro Hero 3+ silver edition has a fisheye lens with a fixed focal length of 2.77 mm, corresponding to a focal length of 16 mm in 35 mm film, if the entire photosensitive area is used.
+For instance, the GoPro Hero 3+ silver edition has a fisheye lens with a fixed focal length of 2.77 mm, corresponding to a focal length of 16 mm in 35 mm film, if the entire photosensitive area is used.
 The GoPro Hero 3+ has three photo modes:
 
--   10 megapixel = 3680 × 2760 pixel wide angle (16 mm in 35 mm film)
--   7 megapixel = 3072 × 2304 pixel wide angle (16 mm in 35 mm film)
--   5 megapixel = 2624 × 1968 pixel medium angle (23 mm in 35 mm film)
+-   10 megapixel = 3680 × 2760 pixel wide angle (16 mm in 35 mm film)
+-   7 megapixel = 3072 × 2304 pixel wide angle (16 mm in 35 mm film)
+-   5 megapixel = 2624 × 1968 pixel medium angle (23 mm in 35 mm film)
 
 The GoPro Hero 3+ is equipped with a 1/2.3" sensor, which has a crop factor of [5.64](http://en.wikipedia.org/wiki/Image_sensor_format).
-(Which gives a focal length of only 15.62 mm in 35 mm film, the 16 mm provided by the EXIF information probably being due to rounding.) The first two modes seem to use the entire photosensitive area; the reduced resolution obviously being achieved by sub-sampling.
+(Which gives a focal length of only 15.62 mm in 35 mm film, the 16 mm provided by the EXIF information probably being due to rounding.) The first two modes seem to use the entire photosensitive area; the reduced resolution obviously being achieved by sub-sampling.
 The distortion parameters are therefore the same, as can be proven in practice.
 The 5-megapixel mode obviously uses only part of the photosensitive area, as 3680 / 2624 × 16 ≈ 23.
 The lens parameters can be determined to
@@ -338,7 +338,7 @@ As an alternative, they can be used to "flatten" the entire video by the [AVIsyn
 
 ### Two Keyboards by El\_Supremo {#keyboard}
 
-The photo that I took of my two keyboards has a very obvious barrel distortion in it, because it was taken at a focal length of 17 mm.
+The photo that I took of my two keyboards has a very obvious barrel distortion in it, because it was taken at a focal length of 17 mm.
 
   
 [![\[IM Output\]](keyboards.jpg)](keyboards.jpg)
@@ -380,12 +380,12 @@ The information for that lens looks like this:
 The calibration entries give distortion values for a range of focal lengths from 17mm up to 85mm.
 If the focal length I needed was between two of those values, I could either choose whichever was closest or I could interpolate the values.
 Since the photo I'm correcting was taken at 17mm I need the information from the first line of the calibration information.
-That gives me the values:  `a="0.021181"  b="-0.055581"  c="0"`
+That gives me the values: `a="0.021181"  b="-0.055581"  c="0"`
 
 These are the three parameters which are used to correct the lens distortion.
 
 However for some older versions of IM, The barrel distortion correction requires a fourth parameter d.
-Fortunately, it is easy to calculate the value of d from the other three using this simple formula:  `d = 1-a-b-c`  That means:  `d="1.0344"`.
+Fortunately, it is easy to calculate the value of d from the other three using this simple formula: `d = 1-a-b-c` That means: `d="1.0344"`.
 
 > ![](../img_www/reminder.gif)![](../img_www/space.gif)
 > IM will work out this value automatically, of it is not provided as a distortion argument, but some older versions of IM did not do this.

--- a/mapping/index.md
+++ b/mapping/index.md
@@ -115,11 +115,11 @@ Added to ImageMagick version 6.5.4-0, the "`-compose`" method '`Blur`' provides 
 ~~~
 composite -blur {Xscale}[x{Yscale}[+{angle}]] blur_map  image   result
 convert image  blur_map  -compose blur \
-    -define compose:args='{Xscale}[x{Yscale}[+{angle}]]' \
-    -composite   result
+    -define compose:args='{Xscale}[x{Yscale}[+{angle}]]' \
+    -composite   result
 convert image  blur_map  -compose blur \
-    -set option:compose:args '{Xscale}[x{Yscale}[+{angle}]]' \
-    -composite   result
+    -set option:compose:args '{Xscale}[x{Yscale}[+{angle}]]' \
+    -composite   result
 ~~~
 
 Note that this [Image Composition](../compose) requires the use of an operational argument, which can be set in a number of ways.
@@ -806,19 +806,16 @@ convert text_image.jpg   map_p_angle.png map_p_radius.png \
 Color Source
   
 ![ +](../img_www/plus.gif)  
- 
   
 [![\[IM Output\]](map_p_angle.png)](map_p_angle.png)  
 Angle - X Map
   
 ![ +](../img_www/plus.gif)  
- 
   
 [![\[IM Output\]](map_p_radius.png)](map_p_radius.png)  
 Radius - Y Map
   
 ![==&gt;](../img_www/right.gif)  
- 
   
 [![\[IM Output\]](distort_p_curved.jpg)](distort_p_curved.jpg)  
 Curved Text
@@ -850,19 +847,16 @@ convert map_p_angular.png map_p_radial.png text.jpg \
 Angular - X Map
   
 ![ +](../img_www/plus.gif)  
- 
   
 [![\[IM Output\]](map_p_radial.png)](map_p_radial.png)  
 Radial - Y Map
   
 ![ +](../img_www/plus.gif)  
- 
   
 [![\[IM Output\]](text.jpg)](text.jpg)  
 Color Source
   
 ![==&gt;](../img_www/right.gif)  
- 
   
 [![\[IM Output\]](distort_p_circle.jpg)](distort_p_circle.jpg)  
 Circled Text
@@ -1496,10 +1490,6 @@ composite mirror_displaced.gif  mirror_cracks.gif -compose multiply \
 [![\[IM Output\]](mirror_areas.gif)](mirror_areas.gif) ![==&gt;](../img_www/right.gif)
   
 [![\[IM Output\]](mirror_dismap_x.gif)](mirror_dismap_x.gif) [![\[IM Output\]](dragon_sm.gif)](dragon_sm.gif) [![\[IM Output\]](mirror_dismap_y.gif)](mirror_dismap_y.gif) ![==&gt;](../img_www/right.gif)
-  
- 
-  
- 
   
 [![\[IM Output\]](mirror_displaced.gif)](mirror_displaced.gif) [![\[IM Output\]](mirror_cracks.gif)](mirror_cracks.gif)
   

--- a/masking/index.md
+++ b/masking/index.md
@@ -65,11 +65,11 @@ The newer operator "`-alpha`" methods are now the recommended method of control,
 An image can not only have alpha channel data, but it also has a 'switch' that defines if the channel data is viewable or valid.
 This means images can have three states with regards to the alpha channel.
   
-* alpha off  - no alpha data (no memory has been allocated)
+*alpha off - no alpha data (no memory has been allocated)
   
-* alpha off  - old alpha data present, but not in use
+*alpha off - old alpha data present, but not in use
   
-* alpha on   - alpha data that is currently in use
+*alpha on  - alpha data that is currently in use
 
 This needs to be remembered as how the various methods behave depends on which of the above three states the image was in.
 If the 'switch' is off, operators will not touch the alpha data, as it may not actually exist at all.

--- a/montage/index.md
+++ b/montage/index.md
@@ -125,7 +125,7 @@ Tile Setting
 3x2
 7 - 8
 4x2
-   
+
 Num Images
 Tile Setting
 9
@@ -140,7 +140,7 @@ Tile Setting
 6x4
 25
 5x5
-   
+
 Num Images
 Tile Setting
 26 - 30
@@ -404,9 +404,9 @@ For example, the montage array in [Annotate Angle Examples](../misc/#annotate) w
 If you do not want this automatic labeling, you must specifically tell "`montage`" to reset all the labels being read in or created to the empty string, using "`-label ''`" before reading the image.
 Or you can just delete the label meta-data using "`+set label`" after reading the images.
 
-This is where "`+label`" differs from using an empty label ("`-label ''`").
+This is where "`+label`" differs from using an empty label ("`-label ''`").
 The former will reset the default behavior back to automatically using any label meta-data that the image being read-in may have, while the latter replaces the label with an empty string, which effectively removes the label.
-You can also preserve the original label of the image using "`-label '%l'`", which can be useful as a NO-OP labeling option in image processing scripts.
+You can also preserve the original label of the image using "`-label '%l'`", which can be useful as a NO-OP labeling option in image processing scripts.
 
 Note that "`-set`" cannot restore the original label of an image, once it has been modified or removed, either by using "`-label`" or "`-set`":
 
@@ -542,7 +542,7 @@ The color outside the drawn frame.
 Often this is set to the '`none`' or '`transparent`', for use on web pages.
 The [-texture](../option_link.cgi?texture) setting will be used instead if given.
 
-- `-bordercolor`  
+- `-bordercolor`
 The fill color inside the frame for images, or any border padding.
 Any transparent areas in an image will become this color, unless no such decoration is added.
 

--- a/quantize/index.md
+++ b/quantize/index.md
@@ -1377,7 +1377,7 @@ convert logo.png +dither -remap netscape:  remap_netscape_nd.gif
 [![\[IM Output\]](remap_netscape.gif)](remap_netscape.gif)
 [![\[IM Output\]](remap_netscape_nd.gif)](remap_netscape_nd.gif)
 
-This color set was a mathematically determined pallet, designed by engineers of displays and computers, not graphic artists, and while it is general enough that it works reasonably well for real images such as photos, it is very bad for images containing large flat areas of color, such as logos, backgrounds, computer generated images such as graphs, and cartoon-like images.
+This color set was a mathematically determined palette, designed by engineers of displays and computers, not graphic artists, and while it is general enough that it works reasonably well for real images such as photos, it is very bad for images containing large flat areas of color, such as logos, backgrounds, computer generated images such as graphs, and cartoon-like images.
 
 Basically, this works in areas of highly variable colors, but for the larger flat areas of constant colors a dithering of three colors (in general) is applied, such as the off-blue shirt of the IM logo test images (above).
 

--- a/quantize/index.md
+++ b/quantize/index.md
@@ -921,7 +921,6 @@ original dither
 one pixel change
   
 ![==&gt;](../img_www/right.gif)  
- 
   
 [![\[IM Output\]](dither_difference.gif)](dither_difference.gif)  
 comparison of changes
@@ -950,7 +949,6 @@ FS Dither
 one pixel change
   
 ![==&gt;](../img_www/right.gif)  
- 
   
 [![\[IM Output\]](dither_fs_difference.gif)](dither_fs_difference.gif)  
 comparison of changes
@@ -2125,8 +2123,10 @@ convert logo.png  -remap colormap_332.png     logo_remap_332.gif
 ~~~
 
 [![\[IM Output\]](logo_o8x8_2.gif)](logo_o8x8_2.gif)
-[![\[IM Output\]](logo_posterize_2.gif)](logo_posterize_2.gif)     [![\[IM Output\]](logo_o8x8_6.gif)](logo_o8x8_6.gif)
-[![\[IM Output\]](logo_posterize_6.gif)](logo_posterize_6.gif)     [![\[IM Output\]](logo_o8x8_332.gif)](logo_o8x8_332.gif)
+[![\[IM Output\]](logo_posterize_2.gif)](logo_posterize_2.gif)
+[![\[IM Output\]](logo_o8x8_6.gif)](logo_o8x8_6.gif)
+[![\[IM Output\]](logo_posterize_6.gif)](logo_posterize_6.gif)
+[![\[IM Output\]](logo_o8x8_332.gif)](logo_o8x8_332.gif)
 [![\[IM Output\]](logo_remap_332.gif)](logo_remap_332.gif)
 
 The first image of each pair in the above is mathematically ordered dithered, while the second is pseudo-randomly 'error correction' dithered.

--- a/quantize/index.md
+++ b/quantize/index.md
@@ -1,40 +1,40 @@
 # Color Quantization and Dithering
 
-Reducing the number of colors or replacing specific colors is a very complex and difficult step in in Image Processing, and that is the topic covered in this example pages.
-This includes determining the what colors to use (color quantization), and how to place those colors on the image (dithering, and patterning).
+Reducing the number of colors or replacing specific colors is a very complex and difficult step in in Image Processing, and that is the topic covered in this example page.
+This includes determining what colors to use (color quantization), and how to place those colors on the image (dithering, and patterning).
 It also includes the generation of bitmap or two color images, and even handling Boolean (on/off) transparency.
 
 This is so important that color reduction or quantization often happens automatically and behind the scene, just so ImageMagick can perform its original primary task of converting images from one file format to another, less colorful format, such as GIF, XPixmap, and XBitmap formats.
-Knowing how this works can allow you greater control of the process, so as to improve the resulting image stored in a specific image file formats.
+Knowing how this works can allow you greater control of the process, so as to improve the resulting image stored in a specific image file format.
 
 ------------------------------------------------------------------------
 
 ## Color Reduction Introduction {#intro}
 
 Color reduction is a very important aspect of ImageMagick.
-For example to convert a JPEG or PNG image containing millions of colors, into a GIF image containing a maximum of 256 color, you really have to be able to reduce colors in a efficient and effective way.
+For example, to convert a JPEG or PNG image containing millions of colors, into a GIF image containing a maximum of 256 colors, you really have to be able to reduce colors in ana efficient and effective way.
 Often during an image format conversion, this happens automatically behind the scenes, but there are other times when you want to do this manually.
 
-Reducing the number of colors in image is a typically a three step process,
+Reducing the number of colors in an image is a typically a three step process,
 
 1.  First you typically need to survey the colors an image uses.
     Not only to see how many colors are actually used, but how often a particular color is used.
     It is no good preserving one specific color, if only a single pixel is using that color, though sometimes you still need to do that.
 2.  Next you need to somehow decide on the final color set to which you want to limit your image.
-    You may what IM to try and dertermine the 'best' set of colors for a specific image.
+    You may want IM to try and determine the 'best' set of colors for a specific image.
     Other times you may want something more general and global that can be used on any image.
-    You may even what to specifically add or remove a color from the set of colors that will be used.
+    You may even want to specifically add or remove a color from the set of colors that will be used.
 3.  And finally you need to modify the image so as to only use the colors you have selected.
     Preferably you want it so the results will look good, or perhaps you want it so that it will compress, compare, or optimize well.
 
 To further complicate matters, these steps are often interlinked, as one method of replacing colors, often can only be applied using specific sets of colors.
 And if you are using a specific set of colors, doing some sort of color survey is not needed, or perhaps you need to make exceptions for specific colors.
 
-Basically while color reduction is often automatically handled behind the scenes, it is good to at least be aware just what it is happening, and what its effects will be.
+Basically while color reduction is often automatically handled behind the scenes, it is good to at least be aware just what is happening, and what its effects will be.
 
 #### Color Survey {#color_survey}
 
-This is probably the lest important, and while IM provides you with methods to perform a survey, it is rarely done by users for the purposes of color reduction.
+This is probably the least important, and while IM provides you with methods to perform a survey, it is rarely done by users for the purposes of color reduction.
 I will leave further discussion to the relevant section, [Extracting Image Colors](#extract).
 
 #### Color Selection (Quantization) {#color_selection}
@@ -65,10 +65,10 @@ convert colorwheel.png \
 The number of colors in each of the final images is only a representative set, but approximately 32 colors in each case (except for threshold which only has 8).
 From this you can get an idea of what you can expect from each of them.
 
-All the other methods have a fix set of colors (according to the operators argument) regardless of the image that is being color reduced.
+All the other methods have a fixed set of colors (according to the operator's argument) regardless of the image that is being color reduced.
 
 Only the first method ("`-colors`") will actually pick colors based on the the current image contents.
-As the test image is predominately white, a lot of lighter colors is selected.
+As the test image is predominantly white, a lot of lighter colors are selected.
 
 It surveys the colors in an image using a technique known as "Adaptive Spatial Subdivision" using octrees.
 Then attempts to choose a specific set of colors to best match a specific image, within the limits given.
@@ -82,9 +82,9 @@ The color map "`colortable.gif`" used in the above, is a set of 32 colors specif
 Using "`-posterize`" can also mathematically divide up each color channel into a set of color levels or intensities producing a 'uniform color map'.
 That is a color map with each channel set to a constant set of values or intensities.
 
-And finally can "`-threshold`" all or specific color channels of the image, essentially making each color channel purely Boolean or on/off.
-That is each color channel can be given a value of zero or MaxRGB (IM 'Q' level dependant).
-This however only produces a minimal set of about about 8 colors.
+And finally, you can "`-threshold`" all or specific color channels of the image, essentially making each color channel purely Boolean or on/off.
+That is, each color channel can be given a value of zero or MaxRGB (IM 'Q' level dependant).
+This, however, only produces a minimal set of about about 8 colors.
 A very limited color set.
 
 Thresholding is also equivalent to a "`-posterize`" level '1' which picks 2 colors.
@@ -94,7 +94,7 @@ Thresholding is also equivalent to a "`-posterize`" level '1' which picks 2 colo
 Once you have a set of colors, the next problem is to apply the color to an image so that the existing colors are replaced by the selected set of colors.
 This is known as 'Dithering', and is named as such because of its, "should I pick this, or should I pick that?", either-or nature.
 
-Basically the idea of dithering is to place pixels of different colors near each other in such a way as to fool the eye into seeing more colors in the image than is actually used.
+Basically, the idea of dithering is to place pixels of different colors near each other in such a way as to fool the eye into seeing more colors in the image than are actually used.
 That is the color in that area of the image more closely matches the original color of the image, because of the way the human eye 'merges' neighbouring colors together.
 
 One of the best introductions to Dithering is on [Wikipedia](http://en.wikipedia.org/wiki/Dither) though you will need to skip over the 'Audio Dithering' section at the start.
@@ -109,8 +109,8 @@ The basic styles of color replacement include...
 -   Digital Halftoning (dots of different sizes)
 
 **Direct mapping** if the nearest color in a given set is what was shown above.
-Basically you get distinct areas of solid, unchanging colors.
-When this is applied to a image of slowing varying color, such as a real life photo of sky, you get bands of colors across the image, especially in what would otherwise be a smooth gradient of colors, such as in sky areas.
+Basically, you get distinct areas of solid, unchanging colors.
+When this is applied to an image of slowing varying color, such as a real life photo of sky, you get bands of colors across the image, especially in what would otherwise be a smooth gradient of colors, such as in sky areas.
 The result is typically regarded as not being very good.
 
 The only time direct color mapping is usually thought of as acceptable is for logos, symbols, icons, and cartoon-like images.
@@ -118,7 +118,7 @@ It is actually rarely an option.
 This is why you generally have to turn off the normal dithering method, if you do not want directly map colors in your images.
 
 Dither however has its own problem.
-Once a image is dithered, a pattern of colors becomes part of the image.
+Once an image is dithered, a pattern of colors becomes part of the image.
 Once such a pattern is present, it is extremely difficult to remove.
 Also it is generally a bad idea to re-apply dithering to an image multiple times, as that just degrades the image.
 
@@ -127,8 +127,8 @@ It is done that way so you can see what color selections are being made before d
 
 **Random dithering** is the simplest dithering method created.
 It is also regarded as the worst possible dithering method.
-However it has some special uses.
-Within IM only works with two colors, so it is usually restricted to special case bitmap dithering.
+However, it has some special uses.
+Within IM, it only works with two colors, so it is usually restricted to special case bitmap dithering.
 For more see [Random Dither with Threshold](#random-threshold) below.
 
 **Error Correction Dithering** is generally regarded as being the best general method of dithering colors across images as it will produce the closest approximation to the original color of areas in the image.
@@ -137,7 +137,7 @@ See [How E-Dithers work](#dither_how) below for more detail.
 
 However Error Correction Dithering has some serious [problems](#dither_sensitive), especially with regards to animations of images.
 
-The last two dithering techniques **Ordered Diffused Pixel** and **Digital Halftoning** is also regarded as a good method, and one that works well for animations, but currently it cannot use any set of colors, only a fixed set of uniform colors.
+The last two dithering techniques **Ordered Diffused Pixel** and **Digital Halftoning** are also regarded as good methods, which also work well for animations, but currently they cannot use any set of colors, only a fixed set of uniform colors.
 
 It does provide a means of coloring an image using patterns, allowing you to produce interesting effects otherwise not easy to produce.
 
@@ -149,13 +149,13 @@ It is well worth the studying.
 ## The Colors in an Image {#handling}
 
 Information about images, such as the number of colors used and the overall spread can be very important to programs and scripts that are trying to make decisions about the best techniques to use.
-Here I look at some of the methods you can use to determine this type of information, and not just for color reduction.
+Here, I look at some of the methods you can use to determine this type of information, and not just for color reduction.
 
 ### Extracting Image Colors {#extract}
 
 #### Extracting the color table {#extract_colortable}
 
-You extract a color palatte from an image using a verbose "`identify`", using any of these methods which basically all does exactly the same thing.
+You extract a color palette from an image using a verbose "`identify`", using any of these methods which basically all do exactly the same thing.
 
 ~~~
 identify -verbose  image.png
@@ -165,8 +165,9 @@ convert  image.png  -verbose info:
 ~~~
 
 > ![](../img_www/reminder.gif)![](../img_www/space.gif)
+> :REMINDER:
 > The output from any of the above verbose identification will not return the color tables or histogram if there are more than 1024 colors!
-> As such for large colorful images this is a hit or miss affair, and not recommended, though it can still be useful.
+> As such, for large colorful images this is a hit or miss affair, and not recommended, though it can still be useful.
 
 The better way however is to generate a "`histogram:`" of the image and extract the comment that is included in the result.
 
@@ -179,6 +180,7 @@ convert  tree.gif  -format %c  -depth 8  histogram:info:-
 [![\[IM Text\]](tree_histogram.txt.gif)](tree_histogram.txt)
   
 > ![](../img_www/warning.gif)![](../img_www/space.gif)
+> :WARNING:
 > The "`info:`" output format was added to IM v6.2.4.
 > For IM versions before this use..
 
@@ -190,7 +192,7 @@ The problem with these methods is that you are given a plain text output of the 
 
 However as of IM v6.2.8-8, the "`-unique-colors`" operator will convert an image into a smaller one containing just one pixel per unique color found in the original image, all in a single row.
 
-This means you can convert a image into a simpler color table image, listing each color present.
+This means you can convert an image into a simpler color table image, listing each color present.
 The width of the image returns the number of colors, and if you need to actually list the colors you can output it to a "`txt:`" image format.
 
 For example here is the color table for the tree image.
@@ -208,7 +210,7 @@ This reduced color table is also very important as a way of storing a colormap o
 Such maps are particularly important for the "`-remap`" color reduction operator.
 (See [Pre-Defined Color Maps](#remap) below)
 
-If you like to get a image containing not just the colors in a image but the color counts, here is one color-histogram solution what was developed from a [IM Forum Discussion](../forum_link.cgi?f=1&t=19538&p=76915).
+If you want to obtain an image containing not just the colors in a image but the color counts, here is one color-histogram solution what was developed from a [IM Forum Discussion](../forum_link.cgi?f=1&t=19538&p=76915).
 
 ~~~
 convert rose: -colors 256 -format %c histogram:info:- |
@@ -232,14 +234,15 @@ The resulting image still contains the same number of pixels, though padded with
 This may not be the best general color histogram method, but it works well for this image.
 
 > ![](../img_www/reminder.gif)![](../img_www/space.gif)
+> :REMINDER:
 > The order of the colors for both "`histogram:`" and "`-unique-colors`" operator, is undefined, but appears to be sorted by red, then green, and finally blue channel value.
 > This may not the best way for a specific image, but it is impossible to generally sort 3-dimensional colors into a 1-dimensional order.
 
 #### Extracting the Average Color {#extract_avg}
 
 The average color of an image can be found very quickly by using "`-scale`" to reduce an image to a single pixel.
-Here for example is the average color of the built-in "`rose:`" image.
-I output the color using the [FX Escape Format](../transform/#fx_escapes) which returns a color string that can be used directly IM without change.
+Here, for example, is the average color of the built-in "`rose:`" image.
+I output the color using the [FX Escape Format](../transform/#fx_escapes) which returns a color string that can be used directly wth IM without change.
 
 ~~~
 convert rose: -scale 1x1\! -format '%[pixel:s]' info:-
@@ -249,7 +252,7 @@ convert rose: -scale 1x1\! -format '%[pixel:s]' info:-
 
 The problem with using the "`%[pixel:...]`" [FX Escape](../transform/#fx_escapes) is that it may return a color name such as '`white`' or '`silver`' instead of a RGB value.
 
-However you can simulate this by using three [FX Escapes](../transform/#fx_escapes) to return the actual RGB values at the bit depth wanted.
+However, you can work around this by using three [FX Escapes](../transform/#fx_escapes) to return the actual RGB values at the bit depth wanted.
 For example...
 
 ~~~
@@ -261,7 +264,7 @@ convert rose: -scale 1x1\! \
 
 As of IM v6.3.9 there are a number of new "`-format`" escapes that can be useful to extract more specific information about images without needing to parse a verbose "`identify`" or "`info:`" output.
 
-For example you can get the average red channel colour by getting the '`%[mean]`' greyscale value from of the images, red channel image.
+For example, you can get the average red channel colour by getting the '`%[mean]`' greyscale value from of the images, red channel image.
 
 ~~~
 convert rose: -channel R -separate -format '%[mean]' info:
@@ -280,7 +283,7 @@ convert rose: -format '%[pixel:p{40,30}]' info:-
 
 [![\[IM Text\]](rose_pixel.txt.gif)](rose_pixel.txt)
 
-Alternativally you can simplify the image by using "`-crop`" to cut out a single pixel that you may be interested in, and just that one pixel, using any of the methods shown above.
+Alternatively, you can simplify the image by using "`-crop`" to cut out a single pixel that you may be interested in, and just that one pixel, using any of the methods shown above.
 For example...
 
 ~~~
@@ -294,7 +297,7 @@ convert rose: -crop 1x1+40+30 -depth 8 txt:-
 This can be used to get the pixel count or percentage of a specific color.
 
 What you do is make anything not that color black, and then make that color white.
-For example lets get the number of colors in the "`yellow`" sun in the 'tree' image.
+For example, let's get the number of colors in the "`yellow`" sun in the 'tree' image.
 
 ~~~
 convert tree.gif -fill black +opaque yellow \
@@ -304,7 +307,7 @@ convert tree.gif -fill black +opaque yellow \
 
 [![\[IM Text\]](tree_sun_pixels.txt.gif)](tree_sun_pixels.txt)
 
-There is one cavat, it will not work if the color under test is itself black.
+There is one caveat, it will not work if the color under test is itself black.
 To handle black (or very dark colors) swap the fills to map non-black colors to white and then [Negate](../color_mods/#negate) the results to generate the white mask of all black pixels.
 
 Remember the "`-print`" option is equivalent to using "`-format ... -write info:`" and can be used anywhere within your image processing.
@@ -312,10 +315,10 @@ I then junked the unwanted image using the special "`null:`" file format.
 You can also save the image to use as a mask for later work too.
 
 Note that while this will work fine for small images, with much larger images (like high resolution digital photos) the 'mean' will not be accurate enough to get an exact pixel count!
-Basically the above use of 'mean' is sutiable for generating a ratio, but not for exact pixel counts.
-To get an exact pixel count you are better of using a histogram 'comment' output that has exact pixel counts (see above).
+Basically, the above use of 'mean' is sutiable for generating a ratio, but not for exact pixel counts.
+To get an exact pixel count, you are better off using a histogram 'comment' output that has exact pixel counts (see above).
 
-The above can also used a [Fuzz Factor](../color_basics/#fuzz) option "`-fuzz`" before the "`-opaque`" operator to specify 'near' colors as well.
+The above can also use a [Fuzz Factor](../color_basics/#fuzz) option "`-fuzz`" before the "`-opaque`" operator to specify 'near' colors as well.
 
 ### Comparing Two Colors {#compare}
 
@@ -339,11 +342,11 @@ compare -metric RMSE xc:'#0000' xc:'#FFF0' null:
 
 [![\[IM Text\]](compare_transparency.txt.gif)](compare_transparency.txt)
 
-Transparent colors should actually have a zero distance as fully transparent is the same regardless of the underlying color.
-Instead we got a 4-d hypercube distance).
-As such the above method of color distance is only suitable for comparing fully-opaque colors only.
+Transparent colors should actually have a zero distance since fully transparent is the same regardless of the underlying color.
+Instead we got a 4-d hypercube distance.
+As such, the above method of color distance is only suitable for comparing fully-opaque colors.
 
-Rather than getting an actual distance, you can also use a **[Fuzz Factor](../color_basics/#fuzz)** to check is two colors are close.
+Rather than getting an actual distance, you can also use a **[Fuzz Factor](../color_basics/#fuzz)** to check if two colors are close.
 
 ~~~
 compare -fuzz 20% -metric AE xc:Navy xc:Blue null:
@@ -412,7 +415,7 @@ else
 fi
 ~~~
 
-The special options "`-alpha set -channel RGBA`" are important to allow us to for fuzzy matching of transparent and near transparent colors.
+The special options "`-alpha set -channel RGBA`" are important to allow us to carry out fuzzy matching of transparent and near transparent colors.
 
 ------------------------------------------------------------------------
 
@@ -420,11 +423,11 @@ The special options "`-alpha set -channel RGBA`" are important to allow us to fo
 
 ### Color Quantization Operator {#colors_operator}
 
-The primary work horse of color quantization, and what is used internally for all automatic color reduction, is the "`-colors`" operator.
+The primary work-horse of color quantization, and what is used internally for all automatic color reduction, is the "`-colors`" operator.
 
-This implements a "Adaptive Spatial Subdivision" color reduction algorithm, and is an extremely good color reduction algorithm.
+This implements an "Adaptive Spatial Subdivision" color reduction algorithm, and is an extremely good color reduction algorithm.
 
-Here is a typical example, I have a image of a 'colorwheel' image containing a lot of colors, and we ask IM to reduce the number of colors down to only 64 colors, using various [dither methods](#dither).
+Here is a typical example, I have an image of a 'colorwheel' containing a lot of colors, and we ask IM to reduce the number of colors down to only 64 colors, using various [dither methods](#dither).
 
 ~~~
 convert colorwheel.png  -dither None       -colors 64  colors_64_no.gif
@@ -439,17 +442,17 @@ convert colorwheel.png  -dither FloydSteinberg \
 [![\[IM Output\]](colors_64_rm.gif)](colors_64_rm.gif)
 [![\[IM Output\]](colors_64_fs.gif)](colors_64_fs.gif)
 
-IM will by default use a 'dither' to shade the colors over the image.
-This prevents the sudden changes in color over smoothly changing gradients.
+IM will, by default, use a 'dither' to shade the colors over the image.
+This prevents sudden changes in color over smoothly changing gradients.
 
 If you turn off dithering (using '`None`' or a "`+dither`" setting) you can clearly see what colors were merged together to generate what IM regarded as the best set of colors for this specific image.
 You can also see the sudden color changes that gradients of color will produce if dithering was not done.
 
 Of course this image uses a lot more colors than what most images use.
-As such while a 64 color limit is often acceptable for many images, it is completely unacceptable for this image.
-In other words color quantization tries to find the best set of colors for a particular image.
+As such, while a 64 color limit is often acceptable for many images, it is completely unacceptable for this image.
+In other words, color quantization tries to find the best set of colors for a particular image.
 
-Here are example of color quantization for part of IM logo, using an extremely small number of colors.
+Here are examples of color quantization for part of IM logo, using an extremely small number of colors.
 
 ~~~
 convert logo: -resize 40% -crop 100x100+105+50\! -normalize  logo.png
@@ -480,11 +483,12 @@ convert rose:  -dither FloydSteinberg \
 [![\[IM Output\]](colors_16_rm.gif)](colors_16_rm.gif)
 [![\[IM Output\]](colors_16_fs.gif)](colors_16_fs.gif)
 
-As you can see cartoon-like images require far less colors than a real photograph to produce a reasonable result.
+As you can see cartoon-like images require far fewer colors than real photographs to produce a reasonable result.
 
 > ![](../img_www/expert.gif)![](../img_www/space.gif)
+> :EXPERT:
 > Only one Color Quantization algorithm, "Adaptive Spatial Subdivision", is currently implemented in IM, and as it works very well, there has been little need to add others.
-> However with feedback this algorithm is being steadily improved.
+> However, with feedback, this algorithm is being steadily improved.
 >
 > ASIDE: As a reference the "`Gifsicle`" program lists a number of other color quantization methods (using it "`--color-method`" option).
 > I have no idea as to how well these color quantization methods compare to IM.
@@ -494,11 +498,11 @@ As you can see cartoon-like images require far less colors than a real photograp
 
 The process of selecting the limited number of colors to use in an image is called Color Quantization, and is a very complex process involving a number of factors.
 A full technical description of it is given on the ImageMagick web site [Color Reduction Algorithm](http://www.imagemagick.org/script/quantize.php).
-However I'll try to example some of the more important aspects of this here.
+However, I'll try to example some of the more important aspects of this here.
 
 Probably the biggest factor is the actual colors used in an image.
-It is no good picking a particular color for an image if their are very few pixels that are 'close' to that color.
-As such the color choice depends not only on the colors used in an image, but the number of pixels 'close' to the color.
+It is no good picking a particular color for an image if there are very few pixels that are 'close' to that color.
+As such, the color choice depends not only on the colors used in an image, but alos the number of pixels 'close' to the color.
 
 I can demonstrate this quite easily by trying to reduce two different two color images to a single common color.
 
@@ -518,7 +522,7 @@ convert colors_br.gif  -colors 1  colors_br2.gif
 ![==&gt;](../img_www/right.gif)
 [![\[IM Output\]](colors_br2.gif)](colors_br2.gif)
 
-As you can see the single final color depends not only on the colors present, but the amount of each color in the image.
+As you can see, the single final color depends not only on the colors present, but the amount of each color in the image.
 
 ~~~
 convert -size 20x640  gradient: -rotate 90  gradient.png
@@ -538,7 +542,7 @@ The other big influence on what colors are selected is defining exactly what we 
 This is defined by the colorspace used for the quantization (color selection), and is (as of IM v6.2.8-6) controlled by the "`-quantize`" colorspace setting.
 
 The "`-quantize`" setting becomes particularly important when a very small number of colors are chosen.
-To demonstrate, lets reduce a standard '[colorwheel](colorwheel.png)' image using various different color spaces and defining different 'color distances'.
+To demonstrate, let's reduce a standard '[colorwheel](colorwheel.png)' image using various different colorspaces and defining different 'color distances'.
 
 ~~~
 for S in    RGB CMY sRGB GRAY \
@@ -565,52 +569,53 @@ done
 [![\[IM Output\]](colors_space_YUV.gif)](colors_space_YUV.gif)
 [![\[IM Output\]](colors_space_OHTA.gif)](colors_space_OHTA.gif)
 
-As you can see the colors chosen depend heavily on how the colorspace is organized.
+As you can see, the colors chosen depend heavily on how the colorspace is organized.
 The sRGB (Red, Green, Blue) color cube will generally result in at least the colors close to the primary color being picked.
 
-The sRGB color space is particularly good at picking colors for cartoon like images and icons, but is actually a bad color space for general picture-like photos.
+The sRGB colorspace is particularly good at picking colors for cartoon-like images and icons, but is actually a bad colorspace for general picture-like photos.
 
-The CMY color space is exactly the same as sRGB color space as the color channels are simply negated to convert between sRGB and CMY colorspaces.
-As such the quantization colors end up with roughly the same solution.
+The CMY colorspace is exactly the same as sRGB colorspace as the color channels are simply negated to convert between sRGB and CMY colorspaces.
+As such, the quantization colors end up with roughly the same solution.
 
 > ![](../img_www/expert.gif)![](../img_www/space.gif)
+> :EXPERT:
 > The CMYK colorspace (not shown) also produces the same but for different reasons.
-> Because internal the 'K' channel and a images 'colormap' use the same data pointer (See [Palette Channel](../basics/#palette)), IM converts it back to CMY before quantization.
+> Because internal the 'K' channel and an image's 'colormap' use the same data pointer (See [Palette Channel](../basics/#palette)), IM converts it back to CMY before quantization.
 
-The sRGB colorspace as expected produces a similar result as RGB, but is warped to remove the number of near-black colors in the colorspace.
-As such there is less colors for the center of the colorwheel to select from, producing a larger 'not quite so black' spot.
-It does however work a lot better for most photos which is why JPEG images often use a sRGB colorspace.
+The sRGB colorspace, as expected, produces a similar result to RGB, but is warped to remove the number of near-black colors in the colorspace.
+As such, there are fewer colors for the center of the colorwheel to select from, producing a larger 'not quite so black' spot.
+It does, however, work a lot better for most photos which is why JPEG images often use a sRGB colorspace.
 
 The XYZ colorspace is also very very similar to linear RGB colorspace.
 The big difference here is that the color axis has shifted so as to better contain ALL the posible colors we can (and even can not) see, as such the color data in the colorwheel are compressed a bit more, and as a result the quantizations seems to become spread out more.
 
-The LAB and LUV color spaces are based on a different but similar color axis which includes negative values.
-That results a different arrangement of color quantizations.
+The LAB and LUV colorspaces are based on a different but similar color axis which includes negative values.
+That results in a different arrangement of color quantizations.
 
-The special color spaces involving a 'Hue' channel, such as HSL (Hue Saturation, Lightness), HSL (Hue, Saturation, Brightness), and HWB (Hue, White, Black), all have a cyclic color wheel representation of color as part of its color space.
-Actually it was using a HSL color space what was used to generate this color wheel.
+The special colorspaces involving a 'Hue' channel, such as HSL (Hue Saturation, Lightness), HSL (Hue, Saturation, Brightness), and HWB (Hue, White, Black), all have a cyclic color wheel representation of color as part of their colorspace.
+Actually, an HSL colorspace was used to generate this color wheel.
 See [Generating a Colorwheel](../color_basics/#colorwheel).
 
 > ![](../img_www/reminder.gif)![](../img_www/space.gif)
+> :REMINDER:
 > At the time of writing, the color distance algorithm IM uses does not take into account the cyclic nature of the 'Hue' of the colorspace.
 > The algorithm for this is very different.
-> Because of this a strong discontinuity occurs along the 'red' path, where the 'Hue' wraps around, and results in very few red colors being selected in the color quantization process.
+> Because of this, a strong discontinuity occurs along the 'red' path, where the 'Hue' wraps around, and results in very few red colors being selected in the color quantization process.
 
 The YIQ, YUV are designed to produce more natural 'pastel' and 'mid-tone' shades of colors that are much better suited for photographs and images of the real world involving subtle shades of colors.
 
-The YIQ, YUV are designed to produce more natural 'pastel' and 'mid-tone' shades of colors that are much better suited for photographs and images of the real world involving subtle shades of colors.
-
-Cristy, the ImageMagick Coordinator, notes that the best colorspace to use should be YIQ as it gives the best result when reducing a photograph of say a persons face to a limited color image such as GIF.
+Cristy, the ImageMagick Coordinator, notes that the best colorspace to use should be YIQ as it gives the best result when reducing a photograph of, say, a person's face, to a limited color image such as GIF.
 I also agree with that recommendation.
 
 Helmut Dersch notes on [his web site](http://www.all-in-one.ee/~dersch/barrel/barrel.html) that you should consider using a LAB colorspace for distortions.
 
 > ![](../img_www/warning.gif)![](../img_www/space.gif)
-> In older versions of IM (specifically IM version 5) the color space that was used for quantization was set with the "`-colorspace`" option.
+> :WARNING:
+> In older versions of IM (specifically IM version 5) the colorspace that was used for quantization was set with the "`-colorspace`" option.
 > However in IM version 6 this operator is used for modifying how images are stored in memory, and as such is not a setting for color quantization.
 >
-> As such in IM v6.2.8-6, the "`-quantize`" setting was provided to do this job.
-> However it is only as setting for the "`-colors`", Color Quantization process.
+> As such, in IM v6.2.8-6, the "`-quantize`" setting was provided to do this job.
+> However, it is only as setting for the "`-colors`", Color Quantization process.
 > It will not do anything for the replacement and dithering of colors using operators such as "`-remap`" and "`-posterize`", or the various dithering techniques.
 
 For a complete list of the colorspaces available see the "`-colorspace`" operator.
@@ -620,21 +625,21 @@ There color quantization is used to reduce the number of colors in a randomized 
 
 ### Quantization does **NOT** Preserve Colors {#quantize_not_exact}
 
-Note that in all the above images a pure-black color is never actually picked by Color Quantization.
-Mind you their is only one pure black pixel, and not many near-black colors in the image in any case.
-As a result the only black that appears in the final image was added later as part of the labeling of the image.
+Note that in all the above images, a pure-black color is never actually picked by Color Quantization.
+Mind you, there is only one pure black pixel, and not many near-black colors in the image in any case.
+As a result, the only black that appears in the final image was added later as part of the labeling of the image.
 
-Even the '`GRAY`' color space image did not produce a pure-black color.
+Even the '`GRAY`' colorspace image did not produce a pure-black color.
 In fact none of the images contains any of the primary or secondary colors, such as: red, blue, green, cyan, magenta!
 The only exception to this is white, as the images did contain quite an amount of pure white color, making it a 'prefered color' (see below).
 
 This situation however is not a bug!
 
-First, a '`black`' color was generally not selected in the above examples, usually because as their is very little black in the original image, so the Color Quantization generally did not worry too much about dark colors.
-In fact it generated more of the lighter colors as these are more common in the image.
+First, a '`black`' color was generally not selected in the above examples, usually because as there is very little black in the original image, so the Color Quantization generally did not worry too much about dark colors.
+In fact, it generated more of the lighter colors as these are more common in the image.
 See the previous section for a specific example.
 
-Secondly, as quantization is trying to pick colors that are close to the maximum number of existing color pixels in an image, this is best achieved by NOT matching a 'pure' primary or secondary color as these are the always at the very extremes of the color space being used.
+Secondly, as quantization is trying to pick colors that are close to the maximum number of existing color pixels in an image, this is best achieved by NOT matching a 'pure' primary or secondary color as these are the always at the very extremes of the colorspace being used.
 An 'off-color' will tend to match more colors than a 'primary' color, so these are more often selected.
 
 So let me be clear...
@@ -642,14 +647,14 @@ So let me be clear...
 **Color Quantization ("`-colors`") will generally avoid picking primary colors!**
 
 As of IM version 6.3 the Color Quantization function was modified to try to include colors that are very common in the original image.
-As such if an image contains a area of a single color (such as '`white`' in the above), that color will generally be included in the final color map.
+As such, if an image contains an area of a single color (such as '`white`' in the above), that color will generally be included in the final color map.
 
-This improves the situation somewhat, especially for 'cartoon' like images or images on a solid color background.
+This improves the situation somewhat, especially for cartoon-like images or images on a solid color background.
 The 'solid' color will generally be picked so as to help avoid [Dither Speckling](#dither_speckle) which we will look at below.
 
 **Specific Color in Colormap Solutions**
 
-At the moment there is only a few ways to gurantee a 'specific color' gets included into the selected colors for later dithering.
+At the moment, there are only a few ways to guarantee a 'specific color' gets included into the selected colors for later dithering.
 
 One way is to quantize the image as normal, but then output the generated color map (using "`-unique-colors`").
 Now you can adjust that color map so your specific color is really that color.
@@ -658,7 +663,7 @@ Finally you can use the [Remap Colors](#remap) operator to dither the image usin
 The colormap may no longer be the BEST colors for the image, and some other colors probably should also be adjusted, but it will be close to the colormap that you wanted.
 
 Alternatively, append large patches of the specific colors wanted to the image, before using "`-colors`".
-The addition of the large 'swatch' of a specific color, will make it more likely to be picks in the final color map.
+The addition of the large 'swatch' of a specific color, will make it more likely to be picked in the final color map.
 Also all the other colors adjusted to fit that color map better).
 
 If this works, you can then just [Crop](../crop/#crop) the image to remove the extra color patches added.
@@ -666,19 +671,19 @@ If it doesn't, then IM should have at least added a color close to the wanted 's
 
 *If you try this, with success or failure, please mail me*
 
-Ideally, what I would like to see added to IM is a way to specify a small number of specific colors, that must be part of the final color map, and then somehow ask IM to pick the best colors for rest of the colors in the color map, for a specific image.
+Ideally, what I would like to see added to IM, is a way to specify a small number of specific colors, that must be part of the final color map, and then somehow ask IM to pick the best colors for rest of the colors in the color map, for a specific image.
 
 ### Color Quantization and Transparency {#color_trans}
 
-ImageMagick by default not only generates fully opaque colors, but also attempts to generate semi-transparent colors.
-In this way, images containing transparent shadows or other overlay effects will not loose those effects.
+ImageMagick, by default, not only generates fully opaque colors, but also attempts to generate semi-transparent colors.
+In this way, images containing transparent shadows or other overlay effects will not lose those effects.
 
-However as IM v6.2.6, color quantization that involves transparency was modified so as to treat all fully-transparent colors as being the same color.
+However, as IM v6.2.6, color quantization that involves transparency was modified so as to treat all fully-transparent colors as being the same color.
 This is a linear modification, so colors which are only half-transparent are also thought to be closer together than if they were fully opaque.
 
-Because of this modification IM Color Quantization will still generate semi-transparent colors, but will concentrate more on the opaque colors and less on the fully transparent colors in the image.
+Because of this modification, IM Color Quantization will still generate semi-transparent colors, but will concentrate more on the opaque colors and less on the fully transparent colors in the image.
 
-For example here I generate a [Rainbow Gradient](../canvas/#gradient_colorspace) of colors, with the image fully-opaque at the top, and fully-transparent at the top.
+For example here I generate a [Rainbow Gradient](../canvas/#gradient_colorspace) of colors, with the image fully opaque at the top, and fully transparent at the top.
 I have displayed the images on a background pattern so that you can see just how transparent the image is.
 
 ~~~
@@ -699,21 +704,21 @@ convert alpha_gradient.png  +dither  -colors 15   alpha_colors_15.png
 As you can see, when we ask IM to reduce the number of colors needed by this image, it created a lot more opaque colors and used fewer highly transparent colors for the more translucent parts.
 The result is a very good spread of colors selected, especially when the number of colors is very small.
 
-However just as I pointed out above, not only do [primary colors not get picked](#quantize_not_exact), but the fully-transparent color will also not get picked for exactly the same reasons.
-In actual fact even fully-opaque colors will not get picked!
-In other words every color in the color quantized images in the previous example is semi-transparent.
+However, just as I pointed out above, not only do [primary colors not get picked](#quantize_not_exact), but the fully transparent color will also not get picked for exactly the same reasons.
+In actual fact, even fully opaque colors will not get picked!
+In other words, every color in the color quantized images in the previous example is semi-transparent.
 
 Let me just make that clear.
 
 **When transparency is involved, IM Color Quantization  
- may not select any fully-opaque or even a fully-transparent color!**
+ may not select any fully-opaque or even a fully transparent color!**
 
-Of course as of IM v6.3, and the 'common color' bug fix (see [Quantization does NOT Preserve Colors](#quantize_not_exact) above), that is less likely to happen if the image contains a lot of opaque and fully-transparent colors, which is commonly the case.
+Of course, as of IM v6.3, and the 'common color' bug fix (see [Quantization does NOT Preserve Colors](#quantize_not_exact) above), that is less likely to happen if the image contains a lot of opaque and fully transparent colors, which is commonly the case.
 
 As some images can contain a lot of semi-transparent colors, such as images involving smoke or shadows effects, you may like to do a trial run, to make sure a fully-transparent color is selected for inclusion in the resulting image.
-You can then map the most-transparent color to fully-transparent, and do the [Remap Colors](#remap) yourself.
+You can then map the most transparent color to fully transparent, and do the [Remap Colors](#remap) yourself.
 
-If you really want to be sure you get both fully-opaque and fully-transparent colors in the resulting image you can [Normalize OR Contrast-Stretch](../color_mods/#normalize) the alpha channel.
+If you really want to be sure you get both fully opaque and fully transparent colors in the resulting image you can [Normalize OR Contrast-Stretch](../color_mods/#normalize) the alpha channel.
 
 For example here I ensure the main color selects are made opaque by using "`-contrast-stretch`".
 Though this is probably a little heavy handed for a more normal situation.
@@ -734,7 +739,7 @@ It only becomes a problem in special cases where you may force a color reduction
 
 Remember for the GIF format saving semi-transparent colors is a useless endeavor.
 As such if you plan to do color quantization yourself for such an image format, you need to tell IM to ignore image transparency when generating its reduced color set.
-you can do that by using the special "`-quantize`" color space setting of '`transparent`'.
+You can do that by using the special "`-quantize`" colorspace setting of '`transparent`'.
 
 ~~~
 convert alpha_gradient.png -quantize transparent \
@@ -745,18 +750,18 @@ convert alpha_gradient.png -quantize transparent \
 ![==&gt;](../img_www/right.gif)
 [![\[IM Output\]](alpha_colors_15qt.png)](alpha_colors_15qt.png)
 
-Notice how the color quantization completely ignored the transparency of the colors, and did not touch the images alpha channel at all.
+Notice how the color quantization completely ignored the transparency of the colors, and did not touch the image's alpha channel at all.
 This means you can process the alpha channel in a more appropriate way for your image, completely separately to the other colors.
-In fact you can do so either before or after using "`-colors`" without problems.
+In fact, you can do so either before or after using "`-colors`" without problems.
 It will make no difference in the result.
 
-This quantization color space is thus recommended when reducing the number of colors for an image you plan to save to a format with Boolean or no transparency, such as GIF or XPM image formats.
+This quantization colorspace is thus recommended when reducing the number of colors for an image you plan to save to a format with Boolean or no transparency, such as GIF or XPM image formats.
 
-If you count up the number of colors generated you will also see that it generated exactly the number of colors requested.
-As such if you you also need a fully transparent color (likely) then you need to reduce the argument of "`-colors`" by at least one, to leave space for it in the images final color table.
+If you count up the number of colors generated, you will also see that it generated exactly the number of colors requested.
+As such, if you also need a fully transparent color (likely) then you need to reduce the argument of "`-colors`" by at least one, to leave space for it in the image's final color table.
 
 Thus to handle the GIF file format 256 color color table limit, you will need to reduce colors to 255, and not 256, leaving the extra space for the fully-transparent color index, as defined by the "`-transparent-color`" setting.
-Adjust this for a smaller color table sizes.
+Adjust this accordingly for smaller color table sizes.
 
 This quantization behaviour is automatic when IM saves to the GIF file format, but is important when you need to DIY the quantization yourself while generating global or shared color tables.
 
@@ -766,7 +771,7 @@ Of course you do still need to handle the semi-transparent pixels, so they are c
     Alpha Channel' to be created in the near future. And a reference to this
     section added here.
 
-Here are some examples of dithering just the alpha channel to just a Boolean or on/off setting, without effecting the rest of the color channels in the image.
+Here are some examples of dithering just the alpha channel to just a Boolean or on/off setting, without affecting the rest of the color channels in the image.
 
 ~~~
 convert alpha_gradient.png \
@@ -802,6 +807,7 @@ convert alpha_gradient.png -channel RGBA -separate \
 [![\[IM Output\]](alpha_dither_map_fs.gif)](alpha_dither_map_fs.gif)
 
 > ![](../img_www/expert.gif)![](../img_www/space.gif)
+> :EXPERT:
 > When dithering a copy of the Alpha Channel, so you can dither it using either "`-monochrome`", or "`-remap`", make sure the image is a pure grayscale image, and not a shape mask containing transparency.
 > If you don't you will probably end up with non-linear effects from the alpha channel still being present.
 >
@@ -813,19 +819,19 @@ convert alpha_gradient.png -channel RGBA -separate \
 
 ## Error Correction Dithering {#dither_error}
 
-As discussed in the introduction an error correction dither is generally regarded the best choice for producing the truest representation of the original image with a reduced color set.
+As discussed in the introduction, an error correction dither is generally regarded as the best choice for producing the truest representation of the original image with a reduced color set.
 It also limits itself to any pre-defined palette of colors, whether it was user supplied, or as determined by the IM color quantization routines.
 
-Because of this it is the logical default choice for general color reduction as provided by the IM operators, "`-colors`", "`-remap`", "`-posterize`" and "`-monochrome`".
+Because of this, it is the logical default choice for general color reduction as provided by the IM operators, "`-colors`", "`-remap`", "`-posterize`" and "`-monochrome`".
 
 ### E-Dither Methods {#dither}
 
 As of version 6.4.2-9, IM now provides more than one type of dithering style or method, which can be selected using the "`-dither`" setting.
-Before this IM was limited to a variation of the [Riemersma Dither](http://www.compuphase.com/riemer.htm), or [Hilbert Curve Dither](http://www.compuphase.com/hilbert.htm).
+Before this, IM was limited to a variation of the [Riemersma Dither](http://www.compuphase.com/riemer.htm), or [Hilbert Curve Dither](http://www.compuphase.com/hilbert.htm).
 Which you can set using "`-dither Riemersma`".
 
 Now you can also select a Floyd-Steiberg Dither using "`-dither FloydSteinberg`".
-You can see what types of dither methods has been implemented in your version of IM using...
+You can see what other dither methods have been implemented in your version of IM using...
 
 ~~~
 convert -list dither
@@ -833,7 +839,7 @@ convert -list dither
 
 [![\[IM Text\]](dithers.txt.gif)](dithers.txt)
 
-For example here is the color wheel dithered using different dithering methods.
+For example, here is the color wheel dithered using different dithering methods.
 
 ~~~
 convert colorwheel.png -dither Riemersma      -colors 16 dither_riemersma.gif
@@ -843,9 +849,9 @@ convert colorwheel.png -dither FloydSteinberg -colors 16 dither_floyd.gif
 [![\[IM Output\]](dither_riemersma.gif)](dither_riemersma.gif)
 [![\[IM Output\]](dither_floyd.gif)](dither_floyd.gif)
 
-As you can see the Floyd-Steinberg dither produces a much more uniform dither pattern than the default Riemersma dither.
+As you can see, the Floyd-Steinberg dither produces a much more uniform dither pattern than the default Riemersma dither.
 The biggest difference between them is how each of them distributes the 'color error' between neighbouring pixels.
-So lets have a look at just how a E-Dither works.
+So let's have a look at just how an E-Dither works.
 
 ### How an E-Dither Works {#dither_how}
 
@@ -856,9 +862,9 @@ This is actually a very good dithering technique, very well defined and reasonab
 For a full description (and a very similar variation) see...
 [Riemersma Dither](http://www.compuphase.com/riemer.htm).
 
-Basically each pixel in the image is looked at in a very complex path known as a '[Hilbert Curve](http://www.compuphase.com/hilbert.htm)'.
-The pixel is assigned the color closest to that pixels value, and any difference between the pixels original color and the selected color, is saved and added to the next pixels color values (which is always a neighbouring pixel) before a new color is again selected.
-In this way any color variations between selected colors and the images original color is distributed to the other pixels in the same area.
+Basically, each pixel in the image is looked at in a very complex path known as a '[Hilbert Curve](http://www.compuphase.com/hilbert.htm)'.
+The pixel is assigned the color closest to that pixel's value, and any difference between the pixels original color and the selected color, is saved and added to the next pixel's color values (which is always a neighbouring pixel) before a new color is again selected.
+In this way, any color variations between selected colors and the image's original color are distributed to the other pixels in the area.
 The result is that while only specific colors will be assigned to the final image, the same basic overall color for that area will closely match the original image.
 
 For example, here is a small grey image that I asked IM to dither using a set of colors that does not include the original color.
@@ -874,9 +880,9 @@ convert -size 10x10 xc:'#999999' \
 ![==&gt;](../img_www/right.gif)
 [![\[IM Output\]](dither.gif)](dither.gif)
 
-As you can see the as the original images color was not in the specified color map, the original color is approximated using a pattern of the three nearest colors that were in the given color table.
+As you can see, as the image's original color was not present in the specified color map, the color is approximated using a pattern of the three nearest colors that were in the given color table.
 
-If we were to average the color generated by the above dither pattern, we would get the color [![\[IM Text\]](dither_avg.txt.gif)](dither_avg.txt), which is very close to the images original average color of [![\[IM Text\]](dither_not_avg.txt.gif)](dither_not_avg.txt) and that is the whole point of the dither pattern that was produced.
+If we were to average the color generated by the above dither pattern, we would get the color [![\[IM Text\]](dither_avg.txt.gif)](dither_avg.txt), which is very close to the image's original average color of [![\[IM Text\]](dither_not_avg.txt.gif)](dither_not_avg.txt) and that is the whole point of the dither pattern that was produced.
 
 However as the 'path' used to assign colors is complex (though generally remains in the local area), the color assignments produce an essentially random pattern.
 It isn't technically random however as the same image will produce the same pattern, but the results may as well be random, or at least pseudo-random.
@@ -898,7 +904,7 @@ convert -size 10x10 xc:'#999999'  -dither FloydSteinberg \
 
 The "Floyd-Stienberg Dither" in particular I find produces a more 'hash' like pattern of pixels than the "Hilbert Curve Dither", and was in fact designed to do so.
 
-Such a regular pattern can make a low level manual clean up of small color icon images, a lot easier.
+Such a regular pattern can make a low level manual clean up of small color icon images a lot easier.
 This was something I did a lot of in my past for [Anthony's Icon Library](http://www.ict.griffith.edu.au/anthony/icons/), but that type of thing is not often needed anymore, except posibly for small monochrome images.
 
 ### E-Dither Problem - Change Sensitive {#dither_sensitive}
@@ -926,7 +932,7 @@ one pixel change
 [![\[IM Output\]](dither_difference.gif)](dither_difference.gif)  
 comparison of changes
 
-As you can see just adding a single pixel to the image resulted in the dither pattern changing dramatically!
+As you can see, just adding a single pixel to the image resulted in the dither pattern changing dramatically!
 It only takes a single bit change for the resulting image to become different, even though overall look of an image (when not enlarged) is still basically the same (which is the purpose of a good dither algorithm after all).
 
 The "`compare`" image also shows the extent of the change in the dither pattern.
@@ -955,7 +961,7 @@ one pixel change
 [![\[IM Output\]](dither_fs_difference.gif)](dither_fs_difference.gif)  
 comparison of changes
 
-As you can see it has exactly the same problem.
+As you can see, it has exactly the same problem.
 A single pixel change causing an almost complete change in the dither pattern for the areas of the image processed after that pixel.
 That is from that row downward.
 
@@ -979,35 +985,36 @@ convert dither_anim.gif -crop 10x10+40+40 +repage \
 ![==&gt;](../img_www/right.gif)
 [![\[IM Output\]](dither_anim_magnify.gif)](dither_anim_magnify.gif)
 
-As you can see you get a sort of churning background to the image, caused by the pseudo-randomness generate by the E-Dither.
-In most cases the colors used are close enough together so as not to make this 'dither noise' visible.
+As you can see, you get a sort of churning background to the image, caused by the pseudo-randomness generate by the E-Dither.
+In most cases, the colors used are close enough together so as not to make this 'dither noise' visible.
 But when the dithering colors are visibly different (in this case forced by the use of a colormap) it definitely becomes an issue.
 
 See [Video Color Optimization](../video/#gif) for a more practical example of an animation showing this 'dither noise'.
 
-The change in pattern also cause problems in optimizing animations.
-That is a different pattern means that simple [frame optimization](../anim_opt/#frame_opt) fails to reduce the size of frame overlays.
+The change in pattern also causes problems in optimizing animations.
+That is, a different pattern means that simple [frame optimization](../anim_opt/#frame_opt) fails to reduce the size of frame overlays.
 For one solution see [fuzzy color optimization](../anim_opt/#color_fuzz), though that only works when the churn is using very similar colors.
 
 > ![](../img_www/reminder.gif)![](../img_www/space.gif)
-> Unlike other dithering methods (such as [threshold](#threshold), and [ordered-dither](#ordered-dither)) the "`-channel`" setting does not effect color quantization, or error correction dithers.
-> Basically has it has no place in how these image operation work.
+> :REMINDER:
+> Unlike other dithering methods (such as [threshold](#threshold), and [ordered-dither](#ordered-dither)) the "`-channel`" setting does not affect color quantization, or error correction dithers.
+> Basically, it has no place in how these image operations work.
 
 Ordered dithers do not have any of these problems, containing changes to the immediate local area of the change.
-Unfortunatally are also generally limited to using a mathematically derived color set.
+Unfortunately they are also generally limited to using a mathematically derived color set.
 (See [Ordered Dither using a Uniform Color Map](#od_posterize)).
 
 ### E-Dither Pixel Speckling {#dither_speckle}
 
 Another problem with E-Dithers is that they can produce the occasional odd-colored pixels in areas which would otherwise be fairly uniform in color.
-For example the occasional green, pixel in a greyscale image.
-Or as in the examples below, a white pixel in a areas of otherwise plain flat blue color.
+For example, the occasional green, pixel in a greyscale image.
+Or, as in the examples below, a white pixel in areas of otherwise plain, flat blue color.
 
-This is especially the case in large images which containing objects with large numbers of colors, and other areas of plain solid unchanging colors.
+This is especially the case in large images containing objects with large numbers of colors, and other areas of plain solid unchanging colors.
 This is especially typical of colored objects overlaid onto flat colored backgrounds, as you often get in diagrams and drawings.
 
-You can see such a odd-colored pixel in the enlargement of the test examples above, where an extra light purple pixel was added quite a distance from the small single pixel change.
-The odd-colored pixels added to the above is not however readily visible and the color map does cover the image rather well, so the odd pixels are reasonably close to the normal three colors used for dithering the image.
+You can see such an odd-colored pixel in the enlargement of the test examples above, where an extra light purple pixel was added quite a distance from the small single pixel change.
+The odd-colored pixels added to the above are not however readily visible and the color map does cover the image rather well, so the odd pixels are reasonably close to the normal three colors used for dithering the image.
 
 For a more extreme example, here I have a blurred gradient background, which I heavily color reduced to 64 colors to really stress the error correction dither.
 
@@ -1036,7 +1043,7 @@ convert -size 100x60 xc:SkyBlue \
 
 You can see that the E-dither suddenly started to produce a sprinkling of white pixels in the upper area of the image where we didn't have any before.
   
-Here is a enlargement a small section so you can see these pixel more clearly...
+Here is an enlargement of a small section so you can see these pixels more clearly...
 
 ~~~
 convert speckle_problem.gif -crop 15x15+75+0 +repage \
@@ -1050,7 +1057,7 @@ The odd colored pixel is caused by two factors.
 First, the Color Quantization was forced to include a single pure white color (but no other white-blue anti-aliasing colors) into the final colormap for the image, thus allowing the dithering process to use this extra color.
 
 But as E-Dithers slowly accumulate errors, especially in areas of extreme colors, such as in the top section of the above image.
-Eventually the errors will add up to a value that is large enough make the one additional color the closest match.
+Eventually the errors will add up to a value that is large enough to make the one additional color the closest match.
 As such, every so often a highly contrasting white pixel is output to 'correct the error', at a pseudo-random location.
 
 The result is a very light speckling of white pixels.
@@ -1061,15 +1068,15 @@ For example convert your GIF format image to PNG.
 This will avoid the need for color quantization (reduction) and hence the need to dither the reduced colors.
 
 The next solution is to replace the use of E-dither with some other dithering method, that 'localizes' any errors, such as [Ordered Dithering](#ordered-dither).
-However that is currently not easy thing to apply in IM at this time.
+However, that is currently not an easy thing to apply in IM at this time.
 See [Better Ordered Dither Results](#od_levels), for one such method until a more general one is found.
 
 If switching to another image format, or using a different dithering method is not practical (and often isn't), then you are left with attempting to fix the situation for that specific image.
 
-**The best fix**, to this is to somehow insure you have other colors just outside the large group of colors that is causing the E-Dither error accumulation.
+**The best fix**, to this is to somehow ensure you have other colors just outside the large group of colors that is causing the E-Dither error accumulation.
 However normal [Color Quantization](#colors) does not do this.
 It tends to pick a set of average colors representing color groups.
-What is needed is extra colors that 'picket fence' the edges of the a large color group, rather than a simple average color.
+What is needed are extra colors that 'picket fence' the edges of the a large color group, rather than a simple average color.
 
 Here for example, I used a circle rather than a square, so that not only is a pure white color added, but a number of white-blue colors also.
 These were added automatically due to the anti-aliasing of the circle edges, to smooth its look.
@@ -1093,16 +1100,16 @@ convert speckle_fixed.gif -crop 15x15+85+0 +repage \
 
 [![\[IM Output\]](speckle_fix_mag.gif)](speckle_fix_mag.gif)
 
-As you can see the additional colors provide the extra colors, just outside the blue-cyan gradient.
+As you can see, the additional colors provide the extra colors, just outside the blue-cyan gradient.
 Now while these extra colors will mean there are fewer colors available for the actual gradient, they do provide other blue-white colors that will allow the E-dither to correct itself sooner and more often, before the accumulated error can grow too large.
 
 That is not to say we have prevented E-dither speckling, just provided better colors for the dither algorithm to work with.
 If you study the magnified portion of the image you will still see a speckle pattern, but the colors are closer to the background color, and there are a lot more of them producing a more even, spread of speckles.
 
 Another way is to generate our own color table, perhaps based on the one IM generated, and add the appropriate colors to prevent the error accumulation.
-This is however not an easy thing to do, especially with a 3-dimentional color space.
+This is however not an easy thing to do, especially with a 3-dimensional colorspace.
 
-For this specific image example, one way to prevent 'speckling' is to generate and dither the background seperatally, with slightly less colors that is needed, then overlay the white box and its additional color.
+For this specific image example, one way to prevent 'speckling' is to generate and dither the background seperately, with slightly fewer colors than needed, then overlay the white box and its additional color.
 
 ~~~
 convert -size 100x60 xc:SkyBlue \
@@ -1120,11 +1127,11 @@ The result is an image with exactly 64 colors, and no speckling at all.
 However this is very dependant on the image and what you are trying to achieve, so is not a general solution to the specking problem.
 
 A more general alternative to adding extra colors is try to remove the speckles from the final dithered image.
-That is clean up the image in some way.
+That is, clean up the image in some way.
 
-However this is itself a tricky problem, as you do not what to remove pixels which are part of the normal dithering pattern.
+However this is itself a tricky problem, as you do not want to remove pixels which are part of the normal dithering pattern.
 
-What we need is to find color pixels which are somehow very different to all the the colors surrounding it, but which are also well isolated from all other similar colors, by some distance.
+What we need is to find pixels which are somehow very different to all the surrounding colors, but which are also well isolated from all other similar colors, by some distance.
 
 The solution is to pass the dithered image though some time of 'speckle filter', such as "`-median`" image filter.
 
@@ -1134,21 +1141,21 @@ convert speckle_problem.gif -median 1 speckle_median.gif
 
 [![\[IM Output\]](speckle_median.gif)](speckle_median.gif)
 
-Note however that the dithering between the various color 'zones' was adversly effected, and the corner of the square was also rounded by this method.
+Note however that the dithering between the various color 'zones' was adversely affected, and the corner of the square was also rounded by this method.
 
 *Do you have a better image filter solution?*
 
 **Summary**
 
-To me speckling is a very annoying problem, especially for desktop icon images using a very limited color table.
-I myself often edit smaller 'icon' images to remove speckles or fix some of the other dithering effects, such a vertical banding.
+To me, speckling is a very annoying problem, especially for desktop icon images using a very limited color table.
+I often edit smaller 'icon' images to remove speckles manually or fix some of the other dithering effects, such as vertical banding.
 
-If you know of another better solution, please let me know.
+If you know of another, better solution, please let me know.
 
 ### Monochrome Dithered Bitmap Images {#monochrome}
 
-The "`-monochrome`" operator is a specialized form of both the "`-colors`" operator to generate a bitmap image.
-It is as such an ideal operator to demonstrate not only 'Hilbert Curve Dithering', but also have a closer look at color selection.
+The "`-monochrome`" operator is a specialized form of the "`-colors`" operator to generate a bitmap image.
+It is therefore an ideal operator to demonstrate not only 'Hilbert Curve Dithering', but also have a closer look at color selection.
 
 Here is a typical example.
 
@@ -1158,7 +1165,7 @@ convert  logo.png  -monochrome     monochrome.gif
 
 [![\[IM Output\]](monochrome.gif)](monochrome.gif)
 
-The operator dithered the image solely based on their grey-scale brightness 'intensity' or 'level', however it doesn't dither the whole grey-scale range directly but thresholds the most extreme values to their maximum values.
+The operator dithered the image solely based on the grey-scale brightness 'intensity' or 'level', however it doesn't dither the whole grey-scale range directly but thresholds the most extreme values to their maximum values.
 
 We can see this by asking IM to dither a gradient image.
 
@@ -1169,8 +1176,8 @@ convert -size 15x640 gradient: -rotate 90 \
 
 [![\[IM Output\]](monochrome_gradient.gif)](monochrome_gradient.gif)
 
-As you can see the gradient only has about the middle 50% of its colors dithered by the "`-monochrome`" operator.
-Special thanks goes to Ivanova &lt;flamingivanova@punkass.com&gt; for pointing out this interesting fact of the was IM works.
+As you can see, the gradient only has about the middle 50% of its colors dithered by the "`-monochrome`" operator.
+Special thanks goes to Ivanova &lt;flamingivanova@punkass.com&gt; for pointing out this interesting fact of the way IM works.
 
 If you like to dither using the whole grey-scale range, you can use the "`-remap`" operator using a pure black and white colormap (supplied by a built-in pattern image).
 
@@ -1183,7 +1190,7 @@ convert -size 15x640 gradient: -rotate 90 \
 [![\[IM Output\]](mono_remap.gif)](mono_remap.gif)
 [![\[IM Output\]](mono_remap_gradient.gif)](mono_remap_gradient.gif)
 
-By more careful selection of colors using "`-remap`" you can effectively produce the same 'threshold' range as used by the "`-monochrome`" operator, or any other threshold range you like.
+By careful selection of colors and using "`-remap`" you can effectively produce the same 'threshold' range as used by the "`-monochrome`" operator, or any other threshold range you like.
 
 ~~~
 convert xc:gray20  xc:white  +append   ctrl_colors.gif
@@ -1196,15 +1203,15 @@ convert -size 15x640 gradient: -rotate 90 \
 [![\[IM Output\]](mono_remap_ctrl.gif)](mono_remap_ctrl.gif)
 [![\[IM Output\]](mono_remap_grad_ctrl.gif)](mono_remap_grad_ctrl.gif)
 
-What "`-monochrome`" actually does is to first convert the given image first into a grey scale image, after that it performs a two color '[Color Quantization](#colors)', to decide the threshold colors to dither the image with.
+What "`-monochrome`" actually does is to first convert the given image into a greyscale image, after that it performs a two color '[Color Quantization](#colors)', to decide the threshold colors to dither the image with.
 This is what the next section of examples will explore.
 
 > ![](../img_www/reminder.gif)![](../img_www/space.gif)
+> :REMINDER:
 > The "`+dither`" setting currently has no effect on the result of "`-monochrome`".
-> This however may change in the future, so make sure it is not turned off in your scripts when using this operator.
+> This, however, may change in the future, so make sure it is not turned off in your scripts when using this operator.
 
 ### Two Color Quantization {#two_color}
-
   
 Rather than picking the two control colors yourself, you can use color quantization to pick the best two colors in the image by using the "`-colors`" operator.
 
@@ -1215,14 +1222,14 @@ convert  logo.png   -colors 2 -colorspace gray  -normalize \
 
 [![\[IM Output\]](colors_monochrome.gif)](colors_monochrome.gif)
 
-However the result will not be the same as using "`-monochrome`", as we didn't convert the image to grey-scale first.
+However, the result will not be the same as using "`-monochrome`", as we didn't convert the image to grey-scale first.
 
-Instead the image was dithered directly between the two non-grey color values chosen.
-That is the best two colors is selected to dither the image with, rather than two gray-scale brightness levels.
-Consequently it will produce a better result for say image that only uses colors of about the same gray-scale 'level'.
+Instead, the image was dithered directly between the two non-grey color values chosen.
+That is, the best two colors are selected to dither the image with, rather than two gray-scale brightness levels.
+Consequently, it will produce a better result for, say, an image that only uses colors of about the same gray-scale 'level'.
 
-Here for example we use "`-colors`", as well as a "`-monochrome`" bitmap dithering operator, on a red-blue gradient.
-As you can so you can see that the results are not the same.
+Here, for example, we use "`-colors`", as well as a "`-monochrome`" bitmap dithering operator, on a red-blue gradient.
+As you can see, the results are not the same.
 
 ~~~
 convert -size 20x640 gradient:red-blue -rotate 90    gradient_rb.png
@@ -1238,11 +1245,11 @@ convert gradient_rb.png       -monochrome       mono_threshold.gif
 The "`-monochrome`" operator in the above failed to find any differences to bitmap dither as both blue and red are very nearly the same intensity.
 Using a "`-colors`" quantization method however had no problem in finding acceptable colors to dither between.
 
-You can also see that only the middle portion of the colors were dithered.
-This is due to the color quantization picking colors in the middle of two color 'clusters' it selected.
-Colors on the 'outside' of the selected colors in is thus effectively threshold directly to that color without dithering.
+You can also see that only the middle portion of the colors was dithered.
+This is due to the color quantization picking colors in between the two color 'clusters' it selected.
+Colors 'outside' or 'beyond' the selected colors are thus effectively thresholded directly to those colors without dithering.
 
-This demonstrates that colors on the outside of the quantization color space does not get dithered, though this fact is difficult to make use of in a practical way.
+This demonstrates that colors on the outside of the quantization colorspace do not get dithered, though this fact is difficult to make use of in a practical way.
   
 By setting the "`-colorspace`" to gray-scale before quantization, you will reproduce the internal operation of the "`-monochrome`" operator.
 
@@ -1263,6 +1270,7 @@ convert  logo.png  -colorspace gray  +dither  -colors 2  -normalize \
 [![\[IM Output\]](threshold_two_grays.gif)](threshold_two_grays.gif)
 
 > ![](../img_www/reminder.gif)![](../img_www/space.gif)
+> :REMINDER:
 > Remember "`-monochrome`" currently ignores the "`+dither`" setting, so you can't just use that operator to do a 'smart threshold'.
 
 If you remove the "`-colorspace`" for the color quantization stage of the image processing, you can threshold an image based on the best color separation (rather than greyscale color separation) possible for that image.
@@ -1276,20 +1284,21 @@ convert  logo.png  +dither  -colors 2  -colorspace gray -normalize \
 
 ### Dither using Pre-Defined Color Maps {#remap}
 
-As shown above "`-colors`" attempts to choose an optimal limited set of colors with which to represent an image.
+As shown above, "`-colors`" attempts to choose an optimal, limited set of colors with which to represent an image.
 With "`-remap`" you provide IM with the final set of colors you want to use for the image, whether you plan to dither those colors, or just replace the ones with their nearest neighbours.
 
-The argument is given as a image containing all the colors you would like to use.
-If you what to reduce a large image of colors to just its list of colors, you can use "`-unique-colors`", before saving, it for later use by "`-remap`".
+The argument is the name of an image containing all the colors you would like to use.
+If you want to reduce a large image to just its list of colors, you can use "`-unique-colors`", before saving it for later use by "`-remap`".
 
 > ![](../img_www/reminder.gif)![](../img_www/space.gif)
+> :REMINDER:
 > Note that while the "`-remap`" operator will accept any image to use, do not use a JPEG image for this image or you will get a lot of extra colors due to its 'lossy compression' generating extra colors.
 >
-> On the other hand using JPEG to generate extra colors may help resolve the 'speckling' problem seen previously!
+> On the other hand, using JPEG to generate extra colors may help resolve the 'speckling' problem seen previously!
 
-For example here I limit the colors used in the IM logo to a predefined map of named X window colors.
+For example, here I limit the colors used in the IM logo to a predefined map of named X window colors.
 The default is the '`Riemersma`' dither, but as of IM v6.4.4 "`-dither`" was expanded to allow the selection of other dither methods such as '`FloydSteinberg`'.
-You can of course still turn off dithering using the "`+dither`" option.
+You can, of course, still turn off dithering using the "`+dither`" option.
 
 ~~~
 convert logo.png  -dither None       -remap colortable.gif  remap_logo_no.gif
@@ -1306,22 +1315,22 @@ convert logo.png  -dither FloydSteinberg \
 [![\[IM Output\]](remap_logo_rm.gif)](remap_logo_rm.gif)
 [![\[IM Output\]](remap_logo_fs.gif)](remap_logo_fs.gif)
 
-As you can see IM attempted to do a reasonable job of representing the image using just the given colors, though the results is nowhere near as good as the image you get if you allowed IM to select the color set to use.
+As you can see, IM attempted to do a reasonable job of representing the image using just the given colors, though the results are nowhere near as good as the image you would get if you allowed IM to select the color set to use.
 
-Mind you this "`colortable.gif`" image was never designed for dithering images, but as a color set for designing cartoon-like color icons for older more primitive X window color displays (See [Anthony's X Window Icon Library](http://www.ict.griffith.edu.au/anthony/icons/) and [AIcons Color Selection](http://www.ict.griffith.edu.au/anthony/icons/docs/colors.html) for details).
+Mind you, this "`colortable.gif`" image was never designed for dithering images, but rather as a color set for designing cartoon-like color icons for older more primitive X window color displays (See [Anthony's X Window Icon Library](http://www.ict.griffith.edu.au/anthony/icons/) and [AIcons Color Selection](http://www.ict.griffith.edu.au/anthony/icons/docs/colors.html) for details).
 
-Also note that the final image did not use all 32 colors provided by this map, though more of the colors in the map will be used when some form of dithering was enabled ([![](remap_logo_count_rm.txt.gif)](remap_logo_count_rm.txt) and [![](remap_logo_count_fs.txt.gif)](remap_logo_count_fs.txt) respectivally), than when it was turned off ([![](remap_logo_count_no.txt.gif)](remap_logo_count_no.txt)).
+Also note that the final image did not use all 32 colors provided by this map, though more of the colors in the map will be used when some form of dithering is enabled ([![](remap_logo_count_rm.txt.gif)](remap_logo_count_rm.txt) and [![](remap_logo_count_fs.txt.gif)](remap_logo_count_fs.txt) respectively), than when it was turned off ([![](remap_logo_count_no.txt.gif)](remap_logo_count_no.txt)).
 
 This last example shows just how important selecting a good colormap is.
-Because of this I recommend you let IM optimize the color selection used in an image using the "`-colors`" operator, and modify that to suit your needs, unless you have more pressing reasons not to do so.
+Because of this, I recommend you let IM optimize the color selection used in an image using the "`-colors`" operator, and modify that to suit your needs, unless you have more pressing reasons not to do so.
 
-One final point, while you can specify a color space in which "`-colors`" will find the best set of colors, you currently can NOT define a color space for the color mapping or dithering phase.
+One final point, while you can specify a colorspace in which "`-colors`" will find the best set of colors, you currently can NOT define a colorspace for the color mapping or dithering phase.
 All my experiments seem to show that the color set is applied (both error correction dither and nearest color replacement) based on RGB space.
 The "`-quantize`" colorspace setting is only used for the selection of colors, not its mapping.
 
 So if using a color map is such a bad idea, why would you want use it?
 
-There are a number common reasons, usually because you need more control of the specific palette of colors used in an image.
+There are a number of common reasons, usually because you need more control of the specific palette of colors used in an image.
 *If you know of another reason to use the "`-remap`" operator which I have not presented below - Mail me.*
 
 #### Common or 'Best' Colormap {#remap_common}
@@ -1329,32 +1338,32 @@ There are a number common reasons, usually because you need more control of the 
 
 The other technique, when handling multiple images, is to generate a common color table for all the images involved.
 
-Basically you append all the images together into one large image, then use the "`-colors`" operator to figure out a good color map to use that is common to all the images.
-Once you have that color map image you can use it to re-color each of the original images using this juts generated [Pre-Defined Color Map](#map).
+Basically, you append all the images together into one large image, then use the "`-colors`" operator to figure out a good color map to use that is common to all the images.
+Once you have that color map image, you can use it to re-color each of the original images using this just generated [Pre-Defined Color Map](#map).
 
 Alternatively, you can use the special "`+remap`" operator, which does the same thing to a 255 color colormap.
-It counts up the colors, perform the color quantization to form a good, common colormap, then dithers the images to use that map, if needed.
+It counts up the colors, performs the color quantization to form a good, common colormap, then dithers the images to use that map, if needed.
 
-Both "`-remap`" and "`+remap`" forms however has one very important feature for GIF animations.
-It converts all the images to a image "`-type`" of '`Palette`' with all the images using the same palette of colors.
+Both "`-remap`" and "`+remap`" forms however have one very important feature for GIF animations.
+They convert all the images to an image "`-type`" of '`Palette`' with all the images using the same palette of colors.
 
-The reason is that when writing a GIF image, the first images color palette, will be used for the file formats 'global colormap'.
-Then as each image is written it notes that those images use the same set of colors, so it does NOT create a 'local colormap'.
-This can save up to 256 × 3, or 768 bytes of colormap space for each and every image the final GIF file.
+The reason is that when writing a GIF image, the first image's color palette, will be used for the file's 'global colormap'.
+Then, as each image is written, it notes that those images use the same set of colors, so it does NOT create a 'local colormap'.
+This can save up to 256x3, or 768 bytes of colormap space for each and every image in the final GIF file.
 
 Only the "`-remap`" operators can do this.
-So when handling GIF's and in particular GIF animations, it can be an important point to remember.
+So when handling GIF's and, in particular GIF animations, it can be an important point to remember.
 
 For more details, and an example see [Gif Animations, Global Color Table](../anim_opt/#colortables).
 
 ### Web Safe Coloring {#web_safe}
 
 When the WWW was first created, computer displays had a limited range of colors available, and web browsers usually used a simpler set of colors for images.
-As such it was common to recolor images to this color set, to make them both smaller, and to ensure they will look okay on users browsers.
+As such, it was common to recolor images to this color set, to make them both smaller, and to ensure they look okay on users' browsers.
 For more detail see [Web Style Guide, Dithering](http://www.webstyleguide.com/graphics/dither.html).
 
-To help with this IM provided a built-in colormap image of this special table of 216 colors, called "`netscape:`".
-So lets look at how our test image would look on of a old web browser display using these colors.
+To help with this, IM provided a built-in colormap image of this special table of 216 colors, called "`netscape:`".
+So let's look at how our test image would look on an old web browser display using these colors.
 
 ~~~
 convert logo.png         -remap netscape:  remap_netscape.gif
@@ -1368,24 +1377,24 @@ convert logo.png +dither -remap netscape:  remap_netscape_nd.gif
 [![\[IM Output\]](remap_netscape.gif)](remap_netscape.gif)
 [![\[IM Output\]](remap_netscape_nd.gif)](remap_netscape_nd.gif)
 
-This color set was a mathematically determined pallet, designed by engineers of displays and computers, not graphic artists, and while it is is general enough that it works reasonably well for real images such as photos, it is very bad for images containing large flat areas of color, such as logos, backgrounds, computer generated images such as graphs, and cartoon-like images.
+This color set was a mathematically determined pallet, designed by engineers of displays and computers, not graphic artists, and while it is general enough that it works reasonably well for real images such as photos, it is very bad for images containing large flat areas of color, such as logos, backgrounds, computer generated images such as graphs, and cartoon-like images.
 
-Basically this works in areas of highly variable colors, but for the larger flat areas of constant colors a dithering of three colors (in general) is applied, such as the off-blue shirt of the IM logo test images (above).
+Basically, this works in areas of highly variable colors, but for the larger flat areas of constant colors a dithering of three colors (in general) is applied, such as the off-blue shirt of the IM logo test images (above).
 
-In other words, if you were designing an image or logo for use on the web, you work generally try to use the colors in this pallet for the large flat areas, and only have dithered colors in areas where your have varying shades of color.
+In other words, if you were designing an image or logo for use on the web, you would generally try to use the colors in this palette for the large flat areas, and only have dithered colors in areas where you have varying shades of color.
 
-The above commands lets you test your images to see how they would look on more primitive computer displays, and to edit image to use these colors, so they will work well.
+The above commands let you test your images to see how they would look on more primitive computer displays, and to edit your image to use these colors, so they will work well.
 This is particularly important for symbols and navigation images.
 
-Of course today, thanks to the demands by game and web users, you can be pretty well assured that most users have a modern computer display that does not have those old color limitations, however the use of this "web safe palette" is still around, as it does have other benefits, such a image compression.
+Of course today, thanks to the demands of game and web users, you can be pretty well assured that most users have a modern computer display that does not have those old color limitations, however the use of this "web safe palette" is still around, as it does have other benefits, such as image compression.
 
 For a discussion about the use of Web-safe colors in the modern world see [Death of the Web-safe Color Palette?](http://www.webmonkey.com/00/37/index2a.html), and probably a more important view from a graphic designer that first identified this color map, [Lynda Weinman](http://www.lynda.com/hex.asp).
 
 ### Generating Color Maps {#remap_colormaps}
 
-Determining a good color map for any image, or a a specific set of images, can be very important.
+Determining a good color map for any image, or a specific set of images, can be very important.
 This becomes especially important when you are dealing with a sequence of images that will be used for GIF animation.
-Basically you want to make it so they only need one color table, to use for all the frames of the animation, rather than a separate color table for each frame.
+Basically, you want to make it so they only need one color table, to use for all the frames of the animation, rather than a separate color table for each frame.
 In other words you want one single color map for all the image.
 
 You have really only two choices in this case.
@@ -1396,13 +1405,13 @@ You can attempt to create a colormap that will work well for any image, or you t
 [![\[IM Output\]](netscape.gif)](netscape.gif)
 
 The first method is typically a mathematically generated color map, such as the IM built-in "`netscape:`" color map.
-This provides a set of 216 colors, which will nicely fit into the GIF formats 256 color limit, and still have space for handling image transparency, or even adding some extra colors for special purposes, like shadows, or text overlays.
+This provides a set of 216 colors, which will nicely fit into the GIF format's 256 color limit, and still have space for handling image transparency, or even adding some extra colors for special purposes, like shadows, or text overlays.
 
 This color map was generated by creating 6 levels of colors for each of the three color channels, producing 6×6×6 colors or 216 colors.
 The number of the beast.
 
-As only 219 color are used it still has space (for GIF images) to add more colors to the color map for specific purposes.
-For example a transparent color, as well as more grey scale shades.
+As only 219 colors are used, it still has space (for GIF images) to add more colors to the color map for specific purposes.
+For example, a transparent color, as well as more grey scale shades.
 An old Macintosh version of the web-safe map actually did exactly this to try to improve its overall result, but it was only used on Macintosh web clients.
 
 This is probably the most common 'uniform' (or mathematically derived) colormap in general use, thanks to its simplicity, and its general use on the the World Wide Web.
@@ -1412,11 +1421,11 @@ This is probably the most common 'uniform' (or mathematically derived) colormap 
 ### Uniform 332 Colormap {#uniform_332_colormap}
 
 Another uniform color mapping that is commonly used is the "332 RGB color map".
-The number refer to the number of bits used to represent each color within a 8 bit color index.
+The number refers to the number of bits used to represent each color within an 8 bit color index.
 That is 3 bits (or 8 levels) of red, 3 for green, and 2 bits (or 4 color levels) for blue, seeing as our eyes do not respond well to blue.
 This gives 3+3+2 bits or an 8 bit color index, or 256 colors.
 Perfect for the limited GIF color table.
-However it will not leave any space for a GIF transparency color, or other special use colors.
+However, it will not leave any space for a GIF transparency color, or other special use colors.
 
 Here is one way to get IM to generate this color map...
 
@@ -1430,13 +1439,13 @@ convert -size 16x16 xc: -channel R -fx '(i%8)/7' \
 [![\[IM Output\]](colormap_332.png)](colormap_332.png)
 
 > ![](../img_www/warning.gif)![](../img_www/space.gif)
-> The bit-shifting operators '`>>`' and '`<<`' was missing from the "`-fx`" operator until IM version 6.2.9-2.
+> :WARNING:
+> The bit-shifting operators '`>>`' and '`<<`' were missing from the "`-fx`" operator until IM version 6.2.9-2.
 
-A simpler way of doing the same thing is to use [Ordered Dither using Uniform Color Levels](#od_posterize) using the operation, "`-ordered-dither threshold,8,8,4`" (see that examples area).
-A far easier and faster technique than the above [DIY FX method](../transform/#fx), and even allows you to use other built-in dithering maps for better gradient handling.
+A simpler way of doing the same thing is to use [Ordered Dither using Uniform Color Levels](#od_posterize) using the operation, "`-ordered-dither threshold,8,8,4`" - a far easier, and faster, technique than the above [DIY FX method](../transform/#fx), and one which even allows you to use other built-in dithering maps for better gradient handling.
 
 The only drawback with this map is that it does not actually provide any 'gray' colors at all.
-However this drawback can be a plus when dithering is used as the slight color differences reduce the effect of color boundary changes in a grey-scale gradient, making it just that little bit smother looking.
+However, this drawback can be a plus when dithering is used as the slight color differences reduce the effect of color boundary changes in a grey-scale gradient, making it just that little bit smother looking.
 
 <a name="16bit_colormap"></a><!-- legacy -->
 
@@ -1447,25 +1456,25 @@ In this case, 16 bits are used for the color index which is divided into 5 bits 
 
 In other words, this color map is more like a "556 colormap", and is best achieved using a [Ordered Dither using Uniform Color Levels](#od_posterize) using a 'threshold' dithermap.
 Specifically the operation "`-ordered-dither threshold,32,32,64`".
-16 bit colormaps are however rarely seen as images using colormaps typically need a 8 bit color table.
-As such I won't mention it further.
+16 bit colormaps are, however, rarely seen as images using colormaps typically need an 8-bit color table.
+As such, I won't mention it further.
 
 ### Gamma Corrected Uniform Colormaps {#gamma_colormap}
 
 At this time IM does not do gamma corrected color maps directly.
 
-Instead what you should do is convert your image (assuming you have Q16 or better compile time [quality](../basics/#quality) version of IM), from the sRGB or whatever gamma level the image has to a linear RGB model, before doing your dithering.
+Instead, what you should do is convert your image (assuming you have Q16 or better compile time [quality](../basics/#quality) version of IM), to a linear RGB model, before doing your dithering.
 
-This also goes for many other image processing operations, such as resize, bluring, etc.
+This also goes for many other image processing operations, such as resize, blurring, etc.
 
 See [Resizing with Gamma Correction](../resize/#resize_gamma) for an example.
 
 ### Posterize, Recolor using a Uniform Color Map {#posterize}
 
-The operators original purpose (using an argument of '2') is to re-color images using just 8 basic colors, as if the image was generated using a simple and cheap poster printing method using just the basic colors.
+The operator's original purpose (using an argument of '2') is to re-color images using just 8 basic colors, as if the image was generated by a simple and cheap poster printing method using just the basic colors.
 Thus the operator gets its name.
 
-The "`-posterize`" operator is actual fact is a special color reduction operator that generates a color map based on the the number of color 'levels' given, for each color channels in the image, dithering the image using an error correction dither.
+The "`-posterize`" operator is, in actual fact, a special color reduction method that generates a color map based on the the number of color 'levels' given, for each color channel in the image, dithering the image using an error correction dither.
 
 ~~~
 convert netscape: -scale 50%  +dither  -posterize 2   posterize_2_ns.gif
@@ -1479,16 +1488,16 @@ convert netscape: -scale 50%  +dither  -posterize 6   posterize_6_ns.gif
 [![\[IM Output\]](posterize_3_ns.gif)](posterize_3_ns.gif)
 [![\[IM Output\]](posterize_6_ns.gif)](posterize_6_ns.gif)
 
-As you can see a "`-posterize`" argument on '`2`' means to only provide 2 colors per color channel, producing a map of just 8 colors for a 3 channel RGB image, such as the above.
-Basically it will recolor images using the threshold set of 8 colors.
+As you can see, a "`-posterize`" argument of '`2`' means to only provide 2 colors per color channel, producing a map of just 8 colors for a 3 channel RGB image, such as the above.
+Basically, it will recolor images using the threshold set of 8 colors.
 
 An argument of '`3`' will map image colors based on a colormap of 27 colors, including mid-tone colors.
 While an argument of '`4`' will generate a 64 color colortable, and '`5`' generates a 125 color colormap.
-Of course as mentioned above, an argument of '`6`' will reproduce the same set of 216 colors, as provided by the in the built-in "`netscape:`" image.
+Of course, as mentioned above, an argument of '`6`' will reproduce the same set of 216 colors, as provided by the in the built-in "`netscape:`" image.
 
 Please note that a "`-posterize`" argument of '`0`' or '`1`' is non-sensible, and with the latest IM releases just converts images to pure black (which though logical, is quite useless).
 
-The result is that the image has been recolors using a mathematically derived or 'uniform' color map.
+The result is that the image has been recolored using a mathematically derived or 'uniform' color map.
 
 You can see this more clearly on a gradient image, producing an even distribution of posterized gray levels.
 
@@ -1499,7 +1508,7 @@ convert gradient.png  +dither  -posterize 5   posterize_gradient.gif
 
 [![\[IM Output\]](posterize_gradient.gif)](posterize_gradient.gif)
 
-For example lets posterize the IM logo image at various levels...
+For example, let's posterize the IM logo image at various levels...
 
 ~~~
 convert logo.png  +dither -posterize 2  posterize_logo.gif
@@ -1513,7 +1522,7 @@ convert logo.png          -posterize 6  posterize_6_logo.gif
 [![\[IM Output\]](posterize_logo_dither.gif)](posterize_logo_dither.gif)
 [![\[IM Output\]](posterize_6_logo.gif)](posterize_6_logo.gif)
 
-As a better test lets poserize the shaded "[colorwheel](colorwheel.png)" image.
+As a better test, let's posterize the shaded "[colorwheel](colorwheel.png)" image.
 
 ~~~
 convert colorwheel.png  +dither  -posterize 2   posterize_2_cw.gif
@@ -1536,10 +1545,10 @@ And here is the same thing with dithering enabled...
 [![\[IM Output\]](posterize_6_dither.gif)](posterize_6_dither.gif)
 
 Of course many of the bitmap dithers we look at in the next section can also generate level 2 ordered dithers, using various sorts of dither styles.
-However few can use a larger number of grey levels.
+However, few can use a larger number of grey levels.
 
-[Ordered Dither](#ordered-dither) as of IM v6.2.9, is also a posterization method, due to its current limitation in dithering using a uniform colormaps.
-However the dither pattern is more uniform, with a larger selection of styles, than the pseudo-randomized dither produced by "`-posterize`".
+[Ordered Dither](#ordered-dither) as of IM v6.2.9, is also a posterization method, due to its current limitation in dithering using uniform colormaps.
+However, the dither pattern is more uniform, with a larger selection of styles, than the pseudo-randomized dither produced by "`-posterize`".
 Compare these with the dithered "`-posterize`" versions above.
 
 ~~~
@@ -1554,10 +1563,9 @@ convert colorwheel.png  -ordered-dither o8x8,6   posterize_6_od.gif
 [![\[IM Output\]](posterize_3_od.gif)](posterize_3_od.gif)
 [![\[IM Output\]](posterize_6_od.gif)](posterize_6_od.gif)
 
-The '`threshold`' dither map (instead of '`o8x8`' used above) effectively converts "`-ordered-dither`" into a un-dithered posterization method.
+The '`threshold`' dither map (instead of '`o8x8`' used above) effectively converts "`-ordered-dither`" into an un-dithered posterization method.
 
-Finally the [Ordered Dither](#ordered-dither) does allow you to specify a different number of color levels, for each individual color channel.
-Something that the "`-posterize`" operator does not currently allow.
+Finally, the [Ordered Dither](#ordered-dither) does allow you to specify a different number of color levels, for each individual color channel - something that the "`-posterize`" operator does not currently allow.
 
 ------------------------------------------------------------------------
 
@@ -1565,9 +1573,9 @@ Something that the "`-posterize`" operator does not currently allow.
 
 ### Threshold Images {#threshold_images}
 
-The simplest method of converting an image into black and white bitmap (to color) image is to use "`-threshold`".
+The simplest method of converting an image into black and white is to use "`-threshold`".
 This is actually a simple mathematical operator that just provides a cut-off value.
-Anything equal to or below that value becomes black, while anything larger becomes white.
+Anything equal to, or below, that value becomes black, while anything larger becomes white.
 
 ~~~
 convert logo.png     -threshold   -1   threshold_0.gif
@@ -1584,7 +1592,7 @@ convert logo.png     -threshold 100%   threshold_100.gif
 [![\[IM Output\]](threshold_100.gif)](threshold_100.gif)
 
 As you can see a value of '`-1`' will convert all colors white, while '`100%`' converts all colors to black.
-A '`50%`' is of course the most common value used.
+A '`50%`' is, of course, the most commonly used value.
   
 A value of '`0`' is a special case which turns all non-pure black colors, white.
 Of course if the image does not have pure-black colors, then you will only get a solid white image!
@@ -1603,10 +1611,10 @@ convert  logo.png  -negate -threshold 0 -negate threshold_white.gif
 
 [![\[IM Output\]](threshold_white.gif)](threshold_white.gif)
 
-The "`-threshold`" operator can be classed as a ultimate 'contrast' operator, maximizing the differences in colors by the threshold level.
+The "`-threshold`" operator can be classed as the ultimate 'contrast' operator, maximizing the differences in colors by the threshold level.
 It is however a gray-scale operator, meaning that the "`-channel`" setting, can be used to adjust which color channel the operator will be applied to.
 
-For example you can threshold each of the individual channels of the image to produce the same effect as a un-dithered level 2 "`-posterize`" operation.
+For example, you can threshold each of the individual channels of the image to produce the same effect as an un-dithered level 2 "`-posterize`" operation.
 
 ~~~
 convert  logo.png  -channel R -threshold 50% \
@@ -1617,11 +1625,12 @@ convert  logo.png  -channel R -threshold 50% \
 [![\[IM Output\]](threshold_posterize.gif)](threshold_posterize.gif)
 
 > ![](../img_www/reminder.gif)![](../img_www/space.gif)
+> :REMINDER:
 > Note that "`-threshold`" treats any transparency in an image as a matte channel, not an alpha channel (just as it is stored internally within IM).
 > As such caution is needed if you plan to apply this operator to the alpha channel.
 > See [Matte Channel](../masking/#matte) for more details.
 
-For a more automatic thresholding technique, you can use a [Two Color Quantization](#two_color) technique that we showed previously.
+For a more automatic thresholding technique, you can use the [Two Color Quantization](#two_color) technique that we showed previously.
 
 For example, this will threshold the image based on the best two colors found in the image.
 These colors may not necessarily be greyscale or even opposites, just the two colors that best represent the whole image.
@@ -1637,12 +1646,12 @@ convert  logo.png  +dither  -colors 2  -colorspace gray -normalize \
 ### Random Dither and Threshold {#random-threshold}
 
 The "`-random-threshold`" operator is a special form of bitmap image converter.
-In this case it uses a very simple "random dither" to determine if a particular pixel is to become a white pixel or a black pixel.
+In this case, it uses a very simple "random dither" to determine if a particular pixel is to become a white pixel or a black pixel.
 
 Unlike the "`-threshold`" or the "`-monochrome`" operators, or even the variations in the previous section, the selected channels (set with "`-channels`") are not merged together into single grey-scale channel and dithered as a single unit.
 Instead "`-random-threshold`" works on each selected channel completely independently of each other.
   
-Of course using the operator directly will result in a 2 level posterization of the image using a random dither.
+Of course, using the operator directly will result in a 2 level posterization of the image using a random dither.
 
 ~~~
 convert  logo.png  -random-threshold  0x100%  random_posterize.gif
@@ -1652,7 +1661,7 @@ convert  logo.png  -random-threshold  0x100%  random_posterize.gif
   
 Converting to gray-scale will equalize all the channels in the image, before they are dithered.
 But as each channel is dithered independent of each other and in a random way, the result is not a bitmap image as you would expect.
-Instead you will get a splatter of color pixels, especially for mid-tone colors.
+Instead, you will get a splatter of colored pixels, especially for mid-tone colors.
 
 ~~~
 convert  logo.png  -colorspace Gray -random-threshold  0x100% \
@@ -1661,7 +1670,7 @@ convert  logo.png  -colorspace Gray -random-threshold  0x100% \
 
 [![\[IM Output\]](random_greyscale.gif)](random_greyscale.gif)
   
-Here is the correct way to generate a proper random dithered bitmap image.
+Here is the correct way to generate a proper, random dithered bitmap image.
 
 ~~~
 convert logo.png  -colorspace Gray -channel B \
@@ -1670,10 +1679,9 @@ convert logo.png  -colorspace Gray -channel B \
 
 [![\[IM Output\]](random_monochome.gif)](random_monochome.gif)
 
-Basically what it did was to only dither one channel of the grey-scaled image, and then use the "`-separate`" channel operator to extract that channel as the final bitmap image.
-Tricky but effective.
-  
-As a special feature for this operator, IM will ensure a bitmap image is generated in the special "`-channels`" option of '`All`' is used.
+Basically, what it did was to only dither one channel of the grey-scaled image, and then use the "`-separate`" channel operator to extract that channel as the final bitmap image - tricky, but effective.
+
+As a special feature of this operator, IM will ensure a bitmap image is generated if the special "`-channels`" option of '`All`' is used.
 
 ~~~
 convert  logo.png  -channel All -random-threshold 0x100% random_all.gif
@@ -1681,10 +1689,10 @@ convert  logo.png  -channel All -random-threshold 0x100% random_all.gif
 
 [![\[IM Output\]](random_all.gif)](random_all.gif)
 
-However please note that any alpha channel will be ignored and lost using this method, as such it is not normally recommended.
-I myself only discovered this ancient feature by accident from the source code.
+However, please note that any alpha channel will be ignored and lost using this method, as such it is not normally recommended.
+I only discovered this ancient feature by accident from the source code.
 
-Now that you know how to use the operator to correctly generate bitmaps from a color image lets look how the argument effects the range of the dithering.
+Now that you know how to use the operator to correctly generate bitmaps from a color image, let's look how the argument affects the range of the dithering.
 This also shows clearly the 'clumping' of pixels that this dither produces.
 
 ~~~
@@ -1707,10 +1715,10 @@ convert gradient.png  -channel All \
 A "`-random-threshold`" setting of '`0x100%`' will produce a purely 'Random Dither' of the image.
 If the two bounds are set to the same value (or even past each other) it will just produce a pure "`-threshold`" image.
 
-Using any other sets of bounds (usually specified using a percentage) will threshold the bitmap outside the given range, while producing a random dither pattern for the values within the given range.
+Using any other sets of bounds (usually specified by percentage) will threshold the bitmap outside the given range, while producing a random dither pattern for the values within the given range.
   
 The best results can be obtained by using a slightly smaller range, just as you get using the "`-monochrome`" operator.
-A value of about '`30x80%`' probably the best result for most cases.
+A value of about '`30x80%`' probably yields the best result for most cases.
 
 ~~~
 convert  logo.png  -channel All -random-threshold 30x80%  random_30x80.gif
@@ -1718,13 +1726,13 @@ convert  logo.png  -channel All -random-threshold 30x80%  random_30x80.gif
 
 [![\[IM Output\]](random_30x80.gif)](random_30x80.gif)
 
-Of course the result is still not very good.
+Of course, the result is still not very good.
 But then this is the simplest and worst form of dithering you can get.
 
 What actually happens is that the randomized dither pattern tends to produce 'clumps' of pixels rather than a smooth dither pattern.
-this is due to the high frequency 'noise' in the random number generator.
-However at very high resolutions a random dither has been shown to produce a extremely good result, if random enough.
-IM uses a cryptographic level of randomness so it will likely be very random, though images are rarely used at a high enough a resolution to make it useful in this way.
+This is due to the high frequency 'noise' in the random number generator.
+However, at very high resolutions, a random dither has been shown to produce an extremely good result, if random enough.
+IM uses a cryptographic level of randomness so it will likely be very random, though images are rarely used at a high enough resolution to make it useful in this way.
 
 One 'fix' for this dither, that has been suggested is to use a random 'blue noise' generator (a high frequency filter, as opposed to a low frequency 'pink noise' filter used in sound production).
 This should remove the clumping of the pixels, but is very difficult to implement digitally.
@@ -1734,34 +1742,34 @@ No known implementation of 'blue noise randomized dither' has been found, and un
 
 ## Ordered Dithering {#ordered-dither}
 
-While a random dither produces random clumps of pixels, and the various error correction dithers produce a essentially random pattern of dots, ordered dithering is basically the opposite.
+While a random dither produces random clumps of pixels, and the various error correction dithers produce an essentially random pattern of dots, ordered dithering is basically the opposite.
 It is designed to be as mathematically deterministic as possible.
-So deterministic, that you actually need to specify the pattern for it to should use in dithering the image.
+So deterministic, that you actually need to specify the pattern for it to use in dithering the image.
 
-The "`-ordered-dither`" operator will dither each of the selected "`-channels`" in the image a given predefined pattern.
+The "`-ordered-dither`" operator will dither each of the selected "`-channels`" in the image in a given, predefined pattern.
 The argument defines the pattern (known as a threshold map) to use.
 
 These threshold maps fall into three basic styles.
 [Diffused Pixel Dithers](#diffused) where the pixels are placed as far from each other as possible, so as to avoid 'clumping' and tiling artifacts.
 Or to clump them together into tight dots that makes them easier to mechanically print, in a technique known as [Digital Halftoning](#halftone).
-There is also some specialized artistic threshold maps that we will also be looking at, and even designing our own dithering pattern or threshold maps.
+There are also some specialized artistic threshold maps that we will be looking at, and even designing our own dithering pattern or threshold maps.
 
-In each case the number of pixels that is on or off in the threshold map depends on the grey-level intensity of the image (or individual color channel) that is being dithered into a bitmap.
+In each case, the number of pixels that is on or off in the threshold map depends on the grey-level intensity of the image (or individual color channel) that is being dithered into a bitmap.
 
 The map adds pixel threshold levels in a consistent manner, so that once a pixel turns on at a particular 'threshold' it remains on for any lighter grey color.
-This consistency is very important, otherwise artifacts are produced along the boundaries of changes the dither pattern.
+This consistency is very important, otherwise artifacts are produced along the boundaries of changes.
 
 The important point about this is that the result for each pixel in an image is purely mathematically determined independently of any other pixel in the image.
-As such any small change to the original image will have absolutely no effect on the image in any other area a problem that [Error Correction Dithers](#dither_error) have, as we saw above.
+As such any small change to the original image will have absolutely no effect on the image in any other area - a problem that [Error Correction Dithers](#dither_error) have, as we saw above.
 
 This point is vital to consistent dithering of video images and optimized animations.
 
 ### Diffused Pixel Dithering {#diffused}
 
-The original purpose of ordered dithering, and what most graphic programmers expect to get when you use an ordered dither is sometime more correctly termed, "Diffused Pixel Ordered Dither".
+The original purpose of ordered dithering, and what most graphic programmers expect to get when using an ordered dither is more correctly termed "Diffused Pixel Ordered Dither".
 
 What this means is that pixels are added to the tiled map as the threshold intensity increases, so that they are as far away from each other and evenly distributed as possible.
-This produces a highly consistent pattern that look quite smooth and near invisible on most modern displays.
+This produces a highly consistent pattern that looks quite smooth and near invisible on most modern displays.
 
 Such patterns have been worked out for tiling sizes that are a power of 2, namely, tile sizes of 2, 4, and 8.
 Though IM also provides a reasonable threshold pattern for a 3 by 3 threshold map tile.
@@ -1784,17 +1792,18 @@ convert logo.png    -ordered-dither o8x8    logo_o8x8.gif
 Note how a larger tile size allows you to simulate more 'color levels', but also generates more noticeable defects or rectangular arrays of pixels at certain levels.
 
 > ![](../img_www/warning.gif)![](../img_www/space.gif)
+> :WARNING:
 > The '`o8x8`' ordered dither was part of the IM core code for a long time, but was not used.
 > It was only added as an option to the "`-ordered-dither`" operator IM v6.2.9, when IM Examples started to detail the use of this operator.
 >
-> At this time the maps were given more definitive names to allow further expansion of the "`-ordered-dither`" operator, though the older backward compatible 'tile size' names, were retained as aliases to the new names.
+> At this time, the maps were given more definitive names to allow further expansion of the "`-ordered-dither`" operator, though the older backward compatible 'tile size' names, were retained as aliases to the new names.
 >
-> Also the 'maps' that produced the 'o3x3' and 'o4x4' were completely revised to produce a better 'diffused pixel' dither pattern.
+> Also, the 'maps' that produced the 'o3x3' and 'o4x4' were completely revised to produce a better 'diffused pixel' dither pattern.
 > Before this the maps produced distinct 'clumps' of pixels.
 >
 > See [Ordered Dither Upgrade](../bugs/ordered-dither/) notes page for examples of the old patterns before they were fixed, as well as other changes made during the development for the official release of the upgrades in IM v6.3.0.
 
-Of course you need to convert the image to grey-scale first to produce a proper bitmap of all the channels in the image, however as the process is not random you don't need to post-process the image as you need to for the [-random-threshold](../option_link.cgi?random-threshold)" operator simplifying things enormously.
+Of course, you need to convert the image to grey-scale first to produce a proper bitmap of all the channels in the image, however as the process is not random you don't need to post-process the image as you need to for the [-random-threshold](../option_link.cgi?random-threshold)" operator simplifying things enormously.
 
 ~~~
 convert logo.png -colorspace Gray  -ordered-dither o2x2  logo_bw_o2x2.gif
@@ -1808,7 +1817,7 @@ convert logo.png -colorspace Gray  -ordered-dither o8x8  logo_bw_o8x8.gif
 [![\[IM Output\]](logo_bw_o4x4.gif)](logo_bw_o4x4.gif)
 [![\[IM Output\]](logo_bw_o8x8.gif)](logo_bw_o8x8.gif)
 
-As a reference here are each of the "`-ordered-dither`" 'diffused pixel' patterns applied to a grey-scale gradient, so you can see clearly what they look like.
+As a reference, here are each of the "`-ordered-dither`" 'diffused pixel' patterns applied to a grey-scale gradient, so you can see clearly what they look like.
 
 ~~~
 # Threshold Non-Dither / Minimal Checkerboard Dither
@@ -1831,13 +1840,13 @@ convert gradient.png   -ordered-dither o8x8       od_o8x8.gif
 [![\[IM Output\]](od_o4x4.gif)](od_o4x4.gif)
 [![\[IM Output\]](od_o8x8.gif)](od_o8x8.gif)
 
-The number of effective or pseudo-level patterns produced by a specific ordered dither, is typically (by not always) equal to the number of pixels in the pattern plus one.
+The number of effective or pseudo-level patterns produced by a specific ordered dither, is typically (but not always) equal to the number of pixels in the pattern plus one.
 As such a '`o3x3`' ordered dither will produce 3×3+1 or 10 effective grey levels per channel (black, white, and 8 artificial gray patterns) in the resulting image.
 
 Also shown above are two special minimal dither threshold maps:
 
 1.  a straight '50% threshold' non-dither, which does not produce any extra grey levels and
-2.  a 'checks' or checkerboard dither pattern, that only inserts a single pattern to add a extra 'pseudo-level' to the resulting gradient.
+2.  a 'checks' or checkerboard dither pattern, that only inserts a single pattern to add an extra 'pseudo-level' to the resulting gradient.
 
 ### Digital Halftone Dithers {#halftone}
 
@@ -1846,15 +1855,16 @@ All of which were set to produce a simple 45 degree dot pattern.
 With IM v6.3.0 this was further expanded with a similar set of larger un-angled halftones.
 
 > ![](../img_www/reminder.gif)![](../img_www/space.gif)
+> :REMINDER:
 > Before the release of IM v6.3.0 halftone screens were selected by using an argument of the form '`{number}x1`'.
-> With the [Re-Development of Ordered Dither](../bugs/ordered-dither/) this limitation was lifted, better naming selected, and extra halftone screens (orthogonal forms) was added (see example arguments below).
+> With the [Re-Development of Ordered Dither](../bugs/ordered-dither/) this limitation was lifted, better naming selected, and extra halftone screens (orthogonal forms) were added - see example arguments below.
 
 Note that digital halftoning is not strictly a true halftone screen, which is designed to handle round dots of ink mechanically deposited onto a medium such as paper, cardboard or even metal.
 Such dots can overlap, and smear during the printing process, thus requiring some non-linear level adjustment.
 This is not needed for producing purely digital halftone effects.
-For more details of the process see the document [Dithering and Halftoning (PDF)](http://www.fho-emden.de/~hoffmann/hilb010101.pdf).
+For more details of the process, see the document [Dithering and Halftoning (PDF)](http://www.fho-emden.de/~hoffmann/hilb010101.pdf).
 
-That said the [Ordered Dither](#ordered-dither) digital halftone patterns do provide the same basic effect as seen in newspapers and cheaply printed magazines.
+That said, the [Ordered Dither](#ordered-dither) digital halftone patterns do provide the same basic effect as seen in newspapers and cheaply printed magazines.
 
 ~~~
 # Halftone Screen (45 degree angle)
@@ -1875,7 +1885,7 @@ convert logo.png   -ordered-dither h8x8o    logo_h8x8o.gif
 [![\[IM Output\]](logo_h6x6o.gif)](logo_h6x6o.gif)
 [![\[IM Output\]](logo_h8x8o.gif)](logo_h8x8o.gif)
 
-Again to use the "`-colorspace`" operator to generate a true bitmap dither of an image.
+Again, use the "`-colorspace`" operator to generate a true bitmap dither of an image.
 
 ~~~
 # Halftone Screen (45 degree angle)
@@ -1896,7 +1906,7 @@ convert logo.png -colorspace Gray  -ordered-dither h8x8o logo_bw_h8x8o.gif
 [![\[IM Output\]](logo_bw_h6x6o.gif)](logo_bw_h6x6o.gif)
 [![\[IM Output\]](logo_bw_h8x8o.gif)](logo_bw_h8x8o.gif)
 
-And finally another gradient reference image to clearly show the halftone dither pattern, and how the pixel clumps within the dither pattern grow into each other as the grey-level changes.
+And finally, another gradient reference image to clearly show the halftone dither pattern, and how the pixel clumps within the dither pattern grow into each other as the grey-level changes.
 
 ~~~
 # Halftone Screen (45 degree angle)
@@ -1929,25 +1939,25 @@ convert gradient.png   -ordered-dither c7x7w      od_c7x7w.gif
 [![\[IM Output\]](od_c7x7b.gif)](od_c7x7b.gif)
 [![\[IM Output\]](od_c7x7w.gif)](od_c7x7w.gif)
 
-Up until ImageMagick version 6.2.9 all the above threshold ordered dither map were all that was possible with IM.
+Up until ImageMagick version 6.2.9 the above threshold ordered dither maps were all that was possible with IM.
 This has now changed, allowing users to add their own patterns, add even contribute them to the IM community.
 
 The 'Circle' halftone thresholds were added by Glenn Randers-Pehrson, IM v6.6.5-6.
 
 ### Offset HalfTone Dither {#halftone_offset}
 
-The only problem with the above halftone dither is that it is that the exact same threshold map (tile) is applied to all the color channels in the same way.
-That means the same set of primary color is arranged in dots with the same 'center'.
+The only problem with the above halftone dither is that the exact same threshold map (tile) is applied to all the color channels in the same way.
+That means the same set of primary colors is arranged in dots with the same 'center'.
 
-To get what is known as 'Offset Printing' the threshold pattern is rotated in a particular pattern such that the colors form small scale 'rosette patterns' that destroyes the more horrible looking interference (moiré) patterns that you could otherwise develop.
+To get what is known as 'Offset Printing' the threshold pattern is rotated in a particular pattern such that the colors form small scale 'rosette patterns' that destroys the more horrible looking interference (Moiré) patterns that could otherwise develop.
 
 This diagram basically explains the process, and is explained in great detail on the Wikipedia Page, [Halftone](http://en.wikipedia.org/wiki/Halftone).
 
 ![\[IM Output\]](cmyk_offset.png)
 
-Note however that the rotated screens do not tile very well, as such the best idea is to actually generate the rotated pattern directly, rather than use a tiles threshold pattern.
+Note, however, that the rotated screens do not tile very well, as such the best idea is to actually generate the rotated pattern directly, rather than use a tiled threshold pattern.
 
-Here is one way to give an image a offset-halftone printing look, using small rotated 2x2 pixel checkerboard pattern, which is about the smallest 'screen' that can be used.
+Here is one way to give an image an offset-halftone printing look, using small rotated 2x2 pixel checkerboard pattern, which is about the smallest 'screen' that can be used.
 
 ~~~
 convert colorwheel.png  -set option:distort:viewport '%wx%h+0+0' \
@@ -1989,33 +1999,33 @@ convert parrots_med.png  -set option:distort:viewport '%wx%h+0+0' \
 
 [![\[IM Output\]](offset_parrots.png)](offset_parrots.png)
 
-Note that the pattern remains very 'square-like' especially the black screen which which all the others are derived.
+Note that the pattern remains very 'square-like', especially the black screen from which all the others are derived.
 
 FUTURE POSSIBILITY: Replace the 2 pixel checkboard in the above with "pattern:gray50" pixel level checkerboard pattern.
 Gaussian filter options can be used to adjust the bluriness of the scaled pattern.
-Alternatively, you can blurry scale the pattern, and thresholded it, to make rounder dots.
+Alternatively, you can blurry scale the pattern, and threshold it, to make rounder dots.
 This can then be rotated as previously to create the 4 color screens.
 
-It also would be better is a larger screen using a pattern of hexagonal dots could be used, rather than the checkerboard pattern I have used above.
+It also would be better if a larger screen using a pattern of hexagonal dots could be used, rather than the checkerboard pattern I have used above.
 
 It is important to note that this is not really generating color dots like true offset printing, but faking it by simply multiplying the color screens against the original image.
 You can see that this is the case due to the sharp color change along the edges of the red parrot against the green background.
 True offset printing using only dots of pure color will not have any middle of dot color changes.
-It is the size of the pure colored dot that should change, depending on the average of the colors in that area reprended by the dot in the source image.
+It is the size of the pure colored dot that should change, depending on the average of the colors in that area represented by the dot in the source image.
 
-To actually generate an true offset printing image only containing round dots in each color channel of appropriate size would require a lot more work.
+To actually generate a true offset printing image only containing round dots in each color channel of appropriate size would require a lot more work.
 The average color in each dot in each color channel will been to be determined, and from that the appropriate size of colored dot (anti-aliased circle) generated.
 *Anyone like to give it a go?*
 
 The above was from a discussion in the IM forum discussion [CMYK Halftone Effect](../forum_link.cgi?f=1&t=18409&p=70730) which looks at how photoshop 'fakes it', and how ImageMagick could achieve the same effect.
 
-This discussion is also related to [B/W Halftone Dither](../forum_link.cgi?f=1&t=17389&p=67746) which takes a closer look at generating true halftone screens using actual dots of appropriate sized.
+This discussion is also related to [B/W Halftone Dither](../forum_link.cgi?f=1&t=17389&p=67746) which takes a closer look at generating true halftone screens using actual dots of appropriate sizes.
 That discussion however did not take it to the next step of using offset (rotated) screens.
 Such screens would probably require rotating the image to generate the dots, then rotating the dot pattern back again for that specific color channel.
 
 ### XML Threshold Maps {#thresholds_xml}
 
-From IM version 6.3.0, rather than using a fixed set of map that were built into the source code of IM (shown previously), the maps are now read in from a set of XML data files external to the program itself.
+From IM version 6.3.0, rather than using a fixed set of maps that were built into the source code of IM (shown previously), the maps are now read in from a set of XML data files external to the program itself.
 
 As part of this change you can now list the available 'threshold maps' that "`-ordered-dither`" operator can use.
 
@@ -2028,17 +2038,17 @@ identify -list threshold
 The above list shows not only the threshold maps available, but also the aliases provided for backwards compatibility or alternate naming, and those defined in my own personal "`thresholds.xml`" XML data file (saved into the "`.magick`" sub-directory of my home).
 
 When "`-ordered-dither`" is looking for a map, the first map that it finds in the above list, will be used.
-As such you can not override a 'system defined threshold pattern.
+As such you can not override a 'system defined' threshold pattern.
 
 The system file "`thresholds.xml`" (the path of which is given by the above "`-list`" option), contains a complete summary of the format of the XML file.
 A format that is simple enough (with error checks by IM) to allow users to define and create their own ordered dither threshold maps.
 
-For example here is a copy of the '`diag5x5`' threshold map I defined in my personal "`threshold.xml`" file.
+For example, here is a copy of the '`diag5x5`' threshold map I defined in my personal "`threshold.xml`" file.
   
 [![\[IM Output\]](tmap_diag.txt.gif)](tmap_diag.txt)
 
-If you look it creates a simple 5x5 map of a single diagonal line that becomes thicker as the threshold level increases.
-The level numbers in the map goes from 0 to 5, one less than the divisor, which declares how many 'grays' it needs to divide the color gradient into.
+If you look, it creates a simple 5x5 map of a single diagonal line that becomes thicker as the threshold level increases.
+The level numbers in the map go from 0 to 5, one less than the divisor, which declares how many 'grays' it needs to divide the color gradient into.
 
 Here is a gradient dithered using this personal threshold map.
 
@@ -2068,18 +2078,18 @@ First I need to also show how to use the coloring abilities of expanded "`-order
 
 ### Ordered Dither using Uniform Color Levels {#od_posterize}
 
-With the release of IM v6.3.0, not only was the threshold maps used by "`-ordered-dither`" changed so as to be read from external files, but the internal operations was enhanced to allow it to use mathematically defined 'posterized' color maps.
+With the release of IM v6.3.0, not only were the threshold maps used by "`-ordered-dither`" changed so as to be read from external files, but the internal operations were enhanced to allow them to use mathematically defined 'posterized' color maps.
 
 This means you can generate a more deterministic dithering of images than you can achieve with 'error correction dithering'.
 This is especially important for color reductions involving animations as you will not get problems from color differences between frames.
 
-The posterization levels is passed to the "`-ordered-dither`" argument using a extra comma separated list of numbers appended to the name of the threshold map to use.
+The posterization levels are passed to the "`-ordered-dither`" using an extra, comma separated list of numbers appended to the name of the threshold map to use.
 If no numbers are provided then the operator falls back to the normal 2 color (or posterize level 1) color map.
 
-For example and argument of '`checks,6`' will use a classic [Web Safe Color Map](#web_safe) (posterized level 6) color map (also defined by the "`netscape:` built-in colormap image).
-However as the minimal dither map of '`checks`' is used a single extra level of dithering is added between each of the 6 color levels creating 11 pseudo-levels of colors in each channel of the image.
+For example, an argument of '`checks,6`' will use a classic [Web Safe Color Map](#web_safe) (posterized level 6) color map (also defined by the "`netscape:` built-in colormap image).
+However, as the minimal dither map of '`checks`' is used a single extra level of dithering is added between each of the 6 color levels creating 11 pseudo-levels of colors in each channel of the image.
 
-In other words even though only 6 levels of color per channel is being used (producing 6^3 or 216 colors) the single dither pattern between levels increases the dither to and effective 11 levels (producing and effective 11^3 or 1331 colors).
+In other words, even though only 6 levels of color per channel are being used (producing 6^3 or 216 colors) the single dither pattern between levels increases the dither to an effective 11 levels (producing an effective 11^3 or 1331 colors).
 
 For example, here is a gray scale gradient dithered using 6 grey levels and various threshold maps.
 The first map '`threshold`' is a special non-dithering ordered dither threshold map, showing just the colors used.
@@ -2098,7 +2108,7 @@ convert gradient.png   -ordered-dither o8x8,6       od_o8x8_6.gif
 [![\[IM Output\]](od_o4x4_6.gif)](od_o4x4_6.gif)
 [![\[IM Output\]](od_o8x8_6.gif)](od_o8x8_6.gif)
 
-As you can see even though only 6 colors are used, with ordered dithering you increase the effective number of colors used to define the gradient, to a point where you can be hard pressed to notice just how few colors were actually used!
+As you can see, even though only 6 colors are used, with ordered dithering you increase the effective number of colors used to define the gradient, to a point where you can be hard pressed to notice just how few colors were actually used!
 
 Not only can you define the number of posterization levels for all channels, but unlike the "`-posterize`" error correction dither option, you can specify the levels for each channel.
 The numbers are assigned to the channels as per the "`-channels`" setting.
@@ -2111,7 +2121,7 @@ convert gradient.png   -ordered-dither o8x8,8,8,4   od_o8x8_884.gif
 
 [![\[IM Output\]](od_o8x8_884.gif)](od_o8x8_884.gif)
 
-Because of the different number of color levels per channel, the above image does not contain just pure grey colors, but includes some bluish and yellowish pixels which cancels each other out to produce extra levels of greys.
+Because of the different number of color levels per channel, the above image does not contain just pure grey colors, but includes some bluish and yellowish pixels which cancel each other out to produce extra levels of greys.
 
 Now compare the [O-dithered](#ordered-dither) version against error correction dithered version using a posterization levels of 2, and 6, and a "332 colormap" (8 levels of red and green, 4 of blue).
 
@@ -2138,7 +2148,7 @@ It was to allow the production the '332 colormap' that the "`-ordered-dither`" o
 
 #### Better Ordered Dither Results {#od_levels}
 
-Lets take a closer look at the level 6 [O-Dither](#ordered-dither) we just generated.
+Let's take a closer look at the level 6 [O-Dither](#ordered-dither) we just generated.
 
 ~~~
 convert logo.png -ordered-dither o8x8,6 -format %k info:
@@ -2146,10 +2156,10 @@ convert logo.png -ordered-dither o8x8,6 -format %k info:
 
 [![\[IM Text\]](logo_color_6.txt.gif)](logo_color_6.txt)
 
-As you can see for this image we did not even come close to filling the GIF color table (256 limit).
-Basically as the image generally consists of mostly blue colors, very few shades of red or even green colors from a level 6 uniform colormap was even used.
+As you can see, for this image, we did not even come close to filling the GIF color table's 256 entry limit.
+Basically, as the image generally consists of mostly blue colors, very few shades of red or even green colors from a level 6 uniform colormap were even used.
 
-However by increasing the number of posterization level we can fill the GIF color table better, so as to produce a better [O-Dithered](#ordered-dither) Image.
+However, by increasing the number of posterization levels, we can fill the GIF color table better, so as to produce a better [O-Dithered](#ordered-dither) Image.
 
 ~~~
 convert logo.png -ordered-dither o8x8,13 -format %k info:
@@ -2159,7 +2169,7 @@ convert logo.png -ordered-dither o8x8,13 -format %k info:
 
   
 This produces enough colors to be only slightly smaller than the GIF color table limits.
-With the increase in the number of colors the result looks a lot better that the results of a simple standard uniform colormap.
+With the increase in the number of colors, the result looks a lot better than the results of a simple, standard, uniform colormap.
 
 ~~~
 convert logo.png -ordered-dither o8x8,13    logo_o8x8_13.gif
@@ -2167,28 +2177,27 @@ convert logo.png -ordered-dither o8x8,13    logo_o8x8_13.gif
 
 [![\[IM Output\]](logo_o8x8_13.gif)](logo_o8x8_13.gif)
 
-As you can see with a high 'levels' value, "`-ordered-dither`" can produce images that are comparable to color quantized, to the specific color picking generated by color quantization and an error correction dither.
+As you can see, with a high 'levels' value, "`-ordered-dither`" can produce images that are comparable to color quantized, to the specific color picking generated by color quantization and an error correction dither.
 
-The major point about these images, is not that they are of high quality.
-After all a full [Color Quantization](#colors) can more easily produce better color map for the image.
-But that the low level dither pattern within the image is fixed, regardless of any small changes that may occur.
+The major point about these images, is not that they are of high quality - after all, a full [Color Quantization](#colors) can more easily produce a better color map for the image.
+The point is that the low level dither pattern within the image is fixed, regardless of any small changes that may occur.
 Only the area changes will be changed in the Ordered Dithered Image.
 
 That is, they do not have the [E-Dither Sensitivity](#dither_sensitive) to change that causes problems for [Frame Optimization](../anim_opt/#frame_opt) in GIF animations.
 (see [Optimization Problem](../anim_opt/#color_fuzz))
 
-Of course for an animation, you will need to "`-append`" all the images together, before checking how many colors is actually used.
+Of course, for an animation, you will need to "`-append`" all the images together, before checking how many colors are actually used.
 And you will need to use the special "`+remap`" option after using the "`-ordered-dither`" to force IM to generate a 'common global colormap' for ALL the images, even though you have already performed color reduction and dithering.
 
-*This method of determining the number of color levels is not simple to determine, but it does works.
+*This method of determining the number of color levels is not simple to determine, but it does work.
 I hope to work out a way for IM to determine the best level automatically, especially for GIF animations.*
 
 ------------------------------------------------------------------------
 
 ## DIY Dither Patterns and Threshold Maps {#diy_dither}
 
-Previously I show you that the new "`-ordered-dither`" operator can accept a user defined dithering pattern.
-Here I am going to show you how you can create your own dither pattern.
+Previously, I showed you that the new "`-ordered-dither`" operator can accept a user defined dithering pattern.
+Here, I am going to show you how you can create your own dither pattern.
 Specifically a special pattern I found useful for generating a shadows consisting of horizontal lines.
 
 ### Multi-Image Dither Patterns {#diy_multi}
@@ -2213,7 +2222,7 @@ montage dpat_hlines2x2.gif    -tile x1 -background none -frame 2 \
 
 This is about the simplest set of dither pattern images you can get, and is very similar to the 'checks' or 'Checkerboard Dither', but with horizontal lines, rather than a checker pattern.
 
-So you can see just what this dither pattern would look like, here is a rather simple DIY ordered dither, that makes direct use of the threshold dithering image set.
+So that you can see just what this dither pattern would look like, here is a rather simple DIY ordered dither, that makes direct use of the threshold dithering image set.
 
 ~~~
 convert gradient.png   dpat_hlines2x2.gif \
@@ -2222,14 +2231,15 @@ convert gradient.png   dpat_hlines2x2.gif \
 
 [![\[IM Output\]](dgrad_hlines2x2.gif)](dgrad_hlines2x2.gif)
 
-As you can see the dither pattern is nothing fancy.
+As you can see, the dither pattern is nothing fancy.
 The "`-fx`" function is a variation of the [Color Lookup Tables](../color_mods/#color_lut) function, namely, an IM Dither Lookup Patterns' type function.
 And with a "`-virtual-pixel`" setting of '`tile`', the function does not even need to know the size of the dither pattern image you are using.
 
 > ![](../img_www/warning.gif)![](../img_www/space.gif)
+> :WARNING:
 > The use of "`-virtual-pixel`" by the "`-fx`" operator using calculated indexes like this was broken before IM version 6.2.9-2.
 
-Lets try this dither pattern set again but using a simple shadowed image...
+Let's try this dither pattern set again but using a simple shadowed image...
 
 ~~~
 convert shadow.png dpat_hlines2x2.gif  -channel A \
@@ -2243,24 +2253,24 @@ convert shadow.png dpat_hlines2x2.gif  -channel A \
 
 ### DIY Ordered Dither Threshold Maps {#diy_threshold}
 
-The above DIY dither pattern is about as simple a dither pattern as you can get, and as such we can convert it directly into a XML threshold map, so that the fast built-in "`-ordered-dither`" operator can make use of it.
+The above DIY dither pattern is about as simple a dither pattern as you can get, and as such, we can convert it directly into an XML threshold map, so that the fast built-in "`-ordered-dither`" operator can make use of it.
 
 Here is the final XML definition, which I saved in my own personal threshold map file "`~/.magick/thresholds.xml`" of my "$HOME" directory.
   
 [![\[IM Output\]](tmap_hlines2x2.txt.gif)](tmap_hlines2x2.txt)
 
 The XML format is very simple, and defines a 2x2 pixel map.
-The first black image is given a value of zero, and has no pixels, so no zero values is present.
-The pixels turned on (made white) in the middle image is set to '`1`' and the remaining or second image pixels are given a value of '`2`'.
+The first black image is given a value of zero, and has no pixels, so no zero values are present.
+The pixels turned on (made white) in the middle image are set to '`1`' and the remaining or second image pixels are given a value of '`2`'.
 
 The '`divisor=`' defines the number of images, or pseudo-color levels (fake color levels) this dither pattern represents, so it has a value of '`3`'.
-It divides the pixel values, to defined the color level at which that pixel is to be turned on.
-As such the top two pixels are turned on for colors larger than 1/3, while the bottom two are turned on for color values larger that 2/3.
+It divides the pixel values, to define the color level at which that pixel is to be turned on.
+As such, the top two pixels are turned on for colors larger than 1/3, while the bottom two are turned on for color values larger than 2/3.
 That is each pixel value represents a 'threshold' level, and why dither patterns are also called threshold maps.
 
 The rest of the definition defines the names (and optional alias) by which you can refer to the threshold map for the ordered dither operator.
 
-So lets try it out...
+So, let's try it out...
 
 ~~~
 convert gradient.png  -ordered-dither hlines2x2  od_hlines2x2.gif
@@ -2273,15 +2283,15 @@ convert shadow.png  -channel A \
 ![==&gt;](../img_www/right.gif)
 [![\[IM Output\]](shadow_hlines2x2.gif)](shadow_hlines2x2.gif)
 
-As you can see the result is reasonably good, but we can do other things to improve the result.
+As you can see, the result is reasonably good, but we can do other things to improve it.
 
-By adjusting the threshold values in the map, we can change the boundary's, so it does not divide the color space into 3 equal areas...
+By adjusting the threshold values in the map, we can change the boundaries, so it does not divide the colorspace into 3 equal areas...
   
 [![\[IM Output\]](tmap_hlines2x2a.txt.gif)](tmap_hlines2x2a.txt)
 
 Note how I increased the divisor to '`10`', so as to divide the color levels into ten equal sections.
 I then changed the threshold settings so that the pattern starts at a 30% threshold at the transparent end (black), to 90% for fully opaque (white).
-And here is the results of changing the threshold map.
+And here are the results of changing the threshold map.
 
 ~~~
 convert gradient.png  -ordered-dither hlines2x2a  od_hlines2x2a.gif
@@ -2292,8 +2302,8 @@ convert shadow.png -channel A \
 [![\[IM Output\]](od_hlines2x2a.gif)](od_hlines2x2a.gif)  
  [![\[IM Output\]](shadow_hlines2x2a.gif)](shadow_hlines2x2a.gif)
 
-As you can see this widened the range of semi-transparent pixels that use pure horizontal lines as a dither pattern.
-This gives a better better shadow effect, though it probably should only be used with a less fuzzy shadow than the example used here.
+As you can see, this widened the range of semi-transparent pixels that use pure horizontal lines as a dither pattern.
+This gives a better shadow effect, though it probably should only be used with a less fuzzy shadow than the example here.
 
 Note however that this type of change to a threshold is very uncommon.
 Though justified for the intended use in this case.
@@ -2344,7 +2354,7 @@ convert sphere_shadow_dither.gif   -fill red  -stroke firebrick \
 ![==&gt;](../img_www/right.gif)
 [![\[IM Output\]](sphere_shadow_hlines.gif)](sphere_shadow_hlines.gif)
 
-The next step is to convert this set of dither patterns into single threshold map image, rather than a set of multiple images.
+The next step is to convert this set of dither patterns into a single threshold map image, rather than a set of multiple images.
 This is achieved by using some fancy image manipulations to merge all the images together.
 
 ~~~
@@ -2383,21 +2393,22 @@ convert gradient.png dmap_hlines.png \
 See how much simpler a threshold map is.
 You have only one image, and one direct comparison to do per pixel, for each channel that is being dithered.
 This makes dithering using a threshold map very very fast.
-Much faster that full color quantization.
+Much faster than full color quantization.
 This simplicity is the why ImageMagick and most graphics software use a threshold map to hold various dither patterns.
 
 > ![](../img_www/reminder.gif)![](../img_www/space.gif)
-> The greater-then or equal ('`>=`') test was not added to the "`-fx`" operator, until IM version 6.2.9-2.
+> :REMINDER:
+> The greater-than or equal ('`>=`') test was not added to the "`-fx`" operator, until IM version 6.2.9-2.
 > If this is a problem, use the inverted test '`v<u`' in the above.
 
-This simplicity however becomes a lot more complicated if the user wanted to dither using multiple color levels.
+This simplicity however becomes a lot more complicated if the user wants to dither using multiple color levels.
 The proof of concept of this was first worked out in the examples on the page [Posterized Ordered Dither](../bugs/ordered-dither/#posterize) before being incorporated into the IM core functions.
 
-Now that we have a merged threshold image, we next need to convert the above image into a XML threshold map, that IM can directly read, and the "`-ordered-dither`" operator can use.
+Now that we have a merged threshold image, we next need to convert the above image into an XML threshold map, that IM can directly read, and the "`-ordered-dither`" operator can use.
 
 To do this we need to output our image as numbers representing the 9 grey levels it represents.
 This is best done using the [NetPBM or PBMplus](../formats/#netpbm) image format, with a depth adjustment using the "[NetPbm](http://netpbm.sourceforge.net/)" image processing software.
-This package is generally a standard linux install so most people will have it already, or can install it from there normal software distribution.
+This package is generally a standard linux install so most people will have it already, or can install it from their normal software distribution.
 
 The "`pnmdepth`" number is again the number of gray levels that the threshold image contains.
 
@@ -2426,9 +2437,9 @@ And that is how you can generate a complex threshold map from a progression of i
 
 ### Dithering with Symbol Patterns {#diy_symbols}
 
-Now while you can use a single threshold map or threshold image, instead of a multi-image pattern set for most dithering operations, that does not mean that multi-image maps don't have there own uses.
+Now, while you can use a single threshold map or threshold image, instead of a multi-image pattern set for most dithering operations, that does not mean that multi-image maps don't have their own uses.
 
-You can use a set of lookup image to tile multiple areas all at once, rather than one at a time.
+You can use a set of lookup images to tile multiple areas all at once, rather than one at a time.
 For example by scaling a simple image, and then replace each pixel in an image with a particular symbol.
 
 For example, here I take the very small 'eyes' image [![\[IM Output\]](eyes.gif)](eyes.gif) and replace the individual pixels with various symbols, to produce such a pattern for each pixel in the original image.
@@ -2446,15 +2457,15 @@ convert eyes.gif -alpha off -colorspace sRGB -grayscale Average \
 [![\[IM Output\]](dpat_syms_images.gif)](dpat_symbols.gif)  
 [![\[IM Output\]](eyes_syms.gif)](eyes_syms.gif)
 
-The [montage](../montage/) is used to expand the multi-image GIF image so that you can see it's contents, without it being 'animated'.
+The [montage](../montage/) is used to expand the multi-image GIF image so that you can see its contents, without it being 'animated'.
 
 You can adjust which "`-grayscale`" intensity method you want to use, from the normal '`Rec709Luminance`' to a darker '`Rec709Luma`', or use a '`average`' of either a non-linear '`sRGB` colorspace, or linear '`RGB`' colorspace.
 You can even adjust the "`-gamma`" scaling of the values to get the best spread of colors.
 
 There are a lot of posibilities, and what is good depends more on your symbol arrangement than actual method chosen.
-The key with the above is to somehow ensure each color in the input image produces a unqiue symbol, and that can be very tricky to achieve.
+The key with the above is to somehow ensure each color in the input image produces a unique symbol, and that can be very tricky to achieve.
 
-This example can be used for creating cross-stitch or knitting guides that hobbists can follow, generating larger scale artwork from smaller comuter images.
+This example can be used for creating cross-stitch or knitting guides that hobbyists can follow, generating larger scale artwork from smaller comuter images.
 
 You can use this technique to tile greyscale images with a set of tiling color images.
 The result is a bit like the landscape maps seen in many old computer war games.
@@ -2478,7 +2489,7 @@ Without this the resulting 'map' is skewed toward wooded landscapes, with little
 As you can see any set of images can be used for the tiles, the images don't even need to line up with each other, or even be the same size tile.
 Of course if the tiles are the same size and are closely related to each other, as in the case of the 3 blue 'sea' tiles, the tiled pattern can 'flow' from one tiled area into another.
 
-By replacing the tile with images of numbers you can also generate a sort of paint by numbers guide.
+By replacing the tile with images of numbers you can also generate a sort of 'paint by numbers' guide.
 However some extra processing may be needed to border the different areas.
 This is left as an exercise, mail your solutions to me, and you can have your name in IM examples as the author for this technique.
 
@@ -2490,9 +2501,9 @@ This is left as an exercise, mail your solutions to me, and you can have your na
 
 ### Ordered Dither with small numbers of colors. {#ordered_dither_small}
 
-When using a small number of colors for a small image a pseudo-random dither like IM's hilbert curve error correction dither, or even a simpler Floyd-Steinberg error correction dither (see [Error Correction Dither](#dither_error) above ) produces a horrible looking result.
+When using a small number of colors for a small image, a pseudo-random dither like IM's hilbert curve error correction dither, or even a simpler Floyd-Steinberg error correction dither (see [Error Correction Dither](#dither_error) above ) produces a horrible looking result.
 
-Ideally an [Ordered Dither](#ordered-dither) should be used with low color and small icon like images to produce a much better looking result.
+Ideally an [Ordered Dither](#ordered-dither) should be used with low color and small icon-like images to produce a much better looking result.
 However at the moment ordered dither in IM can only used 'fixed' mathematically generated color tables, and not just a collection of 'best' colors.
 
 ### Ordered Dither with a map of any colors {#ordered_dther_map}

--- a/quantize/index.md
+++ b/quantize/index.md
@@ -927,7 +927,6 @@ original dither
 one pixel change
   
 ![==&gt;](../img_www/right.gif)  
- 
   
 [![\[IM Output\]](dither_difference.gif)](dither_difference.gif)  
 comparison of changes
@@ -956,7 +955,6 @@ FS Dither
 one pixel change
   
 ![==&gt;](../img_www/right.gif)  
- 
   
 [![\[IM Output\]](dither_fs_difference.gif)](dither_fs_difference.gif)  
 comparison of changes
@@ -2135,8 +2133,10 @@ convert logo.png  -remap colormap_332.png     logo_remap_332.gif
 ~~~
 
 [![\[IM Output\]](logo_o8x8_2.gif)](logo_o8x8_2.gif)
-[![\[IM Output\]](logo_posterize_2.gif)](logo_posterize_2.gif)     [![\[IM Output\]](logo_o8x8_6.gif)](logo_o8x8_6.gif)
-[![\[IM Output\]](logo_posterize_6.gif)](logo_posterize_6.gif)     [![\[IM Output\]](logo_o8x8_332.gif)](logo_o8x8_332.gif)
+[![\[IM Output\]](logo_posterize_2.gif)](logo_posterize_2.gif)
+[![\[IM Output\]](logo_o8x8_6.gif)](logo_o8x8_6.gif)
+[![\[IM Output\]](logo_posterize_6.gif)](logo_posterize_6.gif)
+[![\[IM Output\]](logo_o8x8_332.gif)](logo_o8x8_332.gif)
 [![\[IM Output\]](logo_remap_332.gif)](logo_remap_332.gif)
 
 The first image of each pair in the above is mathematically ordered dithered, while the second is pseudo-randomly 'error correction' dithered.

--- a/resize/index.md
+++ b/resize/index.md
@@ -613,7 +613,7 @@ It seems that adaptive-resize makes the new image much sharper than regular resi
 > For thumbnail generation, the sharpening is too strong, resulting in some aliasing effect being added to the resulting image.
 It is thus better suited to small scale resize adjustments such as generating a smaller image for display on web pages.
 
-You can also generate the exact equivalent result using a [Distort Resize](#distort) operation but with the options "`-filter point -interpolate mesh`".  That is, resizing the image using a simple [Mesh Interpolation](../misc/#mesh) lookup method, rather than a more complex resampling filter.
+You can also generate the exact equivalent result using a [Distort Resize](#distort) operation but with the options "`-filter point -interpolate mesh`". That is, resizing the image using a simple [Mesh Interpolation](../misc/#mesh) lookup method, rather than a more complex resampling filter.
 
 ### Interpolative Resize - Resize using an Interpolation Method {#interpolative-resize}
 

--- a/transform/index.md
+++ b/transform/index.md
@@ -2671,7 +2671,7 @@ Well, this is a little more complex as you can't just multiply them and expect i
 This requires some care to ensure you don't end up clipping the values and getting the right negation of the curve in the resulting image.
 
 The trick is to break up the multiplication into multiple steps.
-That is   **` A × B `**   can also be written as   **` A × abs(B) × sign(B)`**.
+That is **` A × B `** can also be written as **` A × abs(B) × sign(B)`**.
 By doing this, you avoid multiplying by a negative value, which can't be stored in a normal gradient image.
 So all we need to do is take one of the bias gradients and separate it into two parts so they can be applied to the other gradient appropriately.
 

--- a/video/index.md
+++ b/video/index.md
@@ -31,7 +31,7 @@ Also, if you study the resulting animation further you will find that of the [![
 That is each and every frame in the GIF animation required its own color index table.
 That is while each frame has less than 256 colors (due to the GIF format limitations), the whole animation is using a total of [![\[IM Text\]](plane_ncolors.txt.gif)](plane_ncolors.txt) colors.
 
-Unfortunately the GIF format does not compress color tables, so all those extra color tables could be using up to:   256 colors \* 3 byte per color \* 106 frames;   or 81,408 bytes of file space.
+Unfortunately the GIF format does not compress color tables, so all those extra color tables could be using up to: 256 colors \* 3 byte per color \* 106 frames; or 81,408 bytes of file space.
 Not a lot for a 1Gbyte video but still an appreciable amount of space, especially as we optimize the video further.
 
 Added to this is that the animation will not GIF frame optimize very well.

--- a/windows/index.md
+++ b/windows/index.md
@@ -105,9 +105,9 @@ The SendTo folder is named `SendTo`.
 Its location seems to move with each new Windows version.
 A bullet-proof way to find it is typing `shell:sendto` into the run box.
 
-A single command line under Windows XP or later can be 8192 (= 2<sup>13</sup>) characters long.
+A single command line under Windows XP or later can be 8192 (= 2<sup>13</sup>) characters long.
 So if you invoke an IM tool directly from the command line, either directly or via a batch file that names all the files needed directly, you will hardly run into this limitation.
-Drag & Drop however uses the ExecShell routine, which is limited to strings of "only" 2048 (= 2<sup>11</sup>) characters.
+Drag & Drop however uses the ExecShell routine, which is limited to strings of "only" 2048 (= 2<sup>11</sup>) characters.
 As all files are passed with fully qualified filenames (i.e. drive + path + name), this can become a problem for batch files and VBScripts run via WSH when the path names become too long.
 This error cannot be properly handled by the script once it occurs, as the error occurs **before** the script is actually run.
 The solution under Windows XP is usually to place the files in a location where the pathnames are shorter.
@@ -410,7 +410,7 @@ This is just good programming practice.
 
 -   When executing a DOS batch file, the individual commands are echoed by default; that is, commands are displayed in the output DOS box.
 Under UNIX you would instead need to add a special command or option to print commands being exected in this way.
-    You can turn off this 'echoed' output by starting your script with "`@ECHO OFF`".
+    You can turn off this 'echoed' output by starting your script with "`@ECHO OFF`".
 
     The special starting comment "`#!/path/to/shell`" in UNIX shell scripts is not needed for DOS batch files.
     So this line can be replaced by the "`@ECHO OFF`" command for DOS batch files.
@@ -517,7 +517,7 @@ PAUSE
 
 The above batch file manipulates the filename by use of the `~` operator:
   
-%~1  expands %1 removing any surrounding quotes (")
+%~1 expands %1 removing any surrounding quotes (")
   
 %~f1 expands %1 to a fully qualified path name
   
@@ -821,7 +821,7 @@ Therefore, we order the files in a second working step, dumping them in `fsorted
 
 Based on that file, we then construct the Montage command line in another For loop.
 The Montage output file uses the same extension as the first input file (`%~x1`) - assuming that all files share the same extension.
-Please note that the final Montage command is just called by evaluating the environment variable, i. e. `%MONTAGE%`.
+Please note that the final Montage command is just called by evaluating the environment variable, i. e. `%MONTAGE%`.
 
 As has been said in [](), handing over a large number of files with long (full) filename can get you into trouble under Windows XP, because the parameter list of ShellExecute is limited to 2048 characters.
 This error cannot be handled by the batch file, as it occurs **before** the control is handed over to the batch file.
@@ -1165,7 +1165,7 @@ ECHO ImageMagick (convert.exe) not found.
 PAUSE
 ~~~
 
-In the first line, we question the ImageMagick version, suppressing the standard output by `1>nul:` (or just `>nul:`) and any error message by `2>nul:`, i. e. we redirect `stdout` and `stderr` to `nul:`.
+In the first line, we question the ImageMagick version, suppressing the standard output by `1>nul:` (or just `>nul:`) and any error message by `2>nul:`, i. e. we redirect `stdout` and `stderr` to `nul:`.
 If the call to IM's Convert fails, the system program Convert will be called instead, which cannot handle the `-version` option and will set the ERRORLEVEL variable.
 
 You might try to determine why Convert is not found and attempt to fix the problem.
@@ -1337,7 +1337,7 @@ The correction parameter(s) depend on the focal length, which is looked up via `
 For the correction of the Nikon 995 lens, we only need the parameter *b* (i.e. *a, c* = 0), which can be calculcated from the focal length *f* by:
 
 ~~~
-*b* = 0.000005142 *f* ³ - 0.000380839 *f* ² + 0.009606325 *f* - 0.075316854
+*b* = 0.000005142 *f* ³ - 0.000380839 *f* ² + 0.009606325 *f* - 0.075316854
 ~~~
 
 This dependency was found by means of the [lensfun database](http://lensfun.berlios.de/) which lists the barrel distortion parameters for this lens.
@@ -1378,7 +1378,7 @@ When naming the output file, we append "\_pt" to the original filename, just as 
 The filename is stored in `strFileIn`, from which we derive the name of the output file `strFileOut`.
 We then run IM's Identify program.
 The result (i.e. the EXIF rational representing the focal length) is stored in `strf`.
-EXIF rationals are provided as nominator / denominator, e.g. 82 / 10 = 8.2 mm.
+EXIF rationals are provided as nominator / denominator, e.g. 82 / 10 = 8.2 mm.
 The rational thus has to be evaluated before using it in the formula which calculates the parameter *b*.
 
 In the last two lines, we construct the Convert command line and execute the statement via the Run method of the Shell object.


### PR DESCRIPTION
This PU removes the &nbsp; unicode symbol that is not relevant in Markdown documents.
